### PR TITLE
PR 2: Data layer + Daily Rankings route

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,8 @@
       "Bash(pnpm:*)",
       "Bash(python3:*)",
       "Bash(git checkout *)",
-      "Bash(git add *)"
+      "Bash(git add *)",
+      "Bash(git commit *)"
     ]
   }
 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,7 +8,8 @@
       "Bash(python3:*)",
       "Bash(git checkout *)",
       "Bash(git add *)",
-      "Bash(git commit *)"
+      "Bash(git commit *)",
+      "Bash(git push *)"
     ]
   }
 }

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,9 @@
       "Bash(cat:*)",
       "Bash(grep:*)",
       "Bash(pnpm:*)",
-      "Bash(python3:*)"
+      "Bash(python3:*)",
+      "Bash(git checkout *)",
+      "Bash(git add *)"
     ]
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 /test-results/
 /playwright-report/
 /playwright/.cache/
+
+# claude code local overrides
+/.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,11 +10,11 @@ This is a SvelteKit application that displays historical DCI (Drum Corps Interna
 
 This codebase was migrated from Ember.js to SvelteKit in three phased PRs:
 
-- **PR 1 (this commit)**: Scaffold + layout/nav + CI. Both routes are stubs ("Coming soon").
-- **PR 2 (planned)**: Data layer + `/daily-rankings` route.
+- **PR 1**: Scaffold + layout/nav + CI. Both routes are stubs ("Coming soon").
+- **PR 2 (this commit)**: Data layer + `/daily-rankings` route.
 - **PR 3 (planned)**: `/` route with chart action and `buildChartOption`.
 
-Until PR 2/3 land, the app shell renders but no real content.
+Until PR 3 lands, `/` is still a stub.
 
 ## Development Commands
 
@@ -80,14 +80,14 @@ src/
 │   │   ├── nav/{NavigationBar,Logo,DesktopMenu,MobileMenu,MobileMenuToggle}.svelte
 │   │   ├── nav/types.ts              # NavItem type + NAV_ITEMS list
 │   │   └── shared/{Card,PageContent,PageHeader}.svelte
-│   ├── data/                         # (PR 2) base.ts, index.ts, seasons/[year].ts
+│   ├── data/                         # base.ts, index.ts, seasons/[year].ts
 │   ├── actions/                      # (PR 3) chart.ts
-│   └── utils/                        # (PR 2/3) url-state.ts, chart-options.ts, ordinal.ts
+│   └── utils/                        # url-state.ts, ordinal.ts, daily-rankings.ts, chart-options.ts (PR 3)
 └── routes/
     ├── +layout.svelte                # Renders <NavigationBar /> + children
     ├── +layout.ts                    # `export const prerender = true`
     ├── +page.svelte                  # Score History (stub until PR 3)
-    └── daily-rankings/+page.svelte   # Daily Rankings (stub until PR 2)
+    └── daily-rankings/+page.svelte   # Daily Rankings
 
 static/
 ├── CNAME                             # bluecoats.pfefferle.me
@@ -142,15 +142,23 @@ Direct string `href`s to internal routes will trigger `svelte/no-navigation-with
 
 For the active-link state, read `page.route.id` from `$app/state` (not `$app/stores` — Svelte 5 prefers `$app/state`).
 
-#### URL State (planned PR 2/3)
+#### URL State
 
-Query-param-driven UI state lives in the URL, written via a small helper at `src/lib/utils/url-state.ts` that wraps `goto(url, { replaceState: true, keepFocus: true, noScroll: true })`.
+Query-param-driven UI state lives in the URL, written via `setParam(key, value)` from `src/lib/utils/url-state.ts` (wraps `goto` with `replaceState: true, keepFocus: true, noScroll: true`).
+
+**Important**: prerendered pages cannot read `page.url.searchParams` at build time. Gate the read on `browser` from `$app/environment`:
+
+```svelte
+const dayParam = $derived(browser ? page.url.searchParams.get('day') : null);
+```
+
+The prerendered HTML reflects the default state (no query params); on hydration, the client picks up the real URL and re-derives.
 
 #### Chart Action (planned PR 3)
 
 ECharts is wired via a Svelte action at `src/lib/actions/chart.ts` that handles init, update (with `notMerge: true`), `ResizeObserver`, and `dispose()` on destroy. Import lazily inside the action body if bundle size is a concern.
 
-### Adding New Season Data (planned PR 2)
+### Adding New Season Data
 
 1. Create `src/lib/data/seasons/[year].ts` following the existing pattern.
 2. Export `SEASON_[year]` constant with type `SeasonScores`.

--- a/src/lib/components/daily-rankings/DaySlider.svelte
+++ b/src/lib/components/daily-rankings/DaySlider.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  let {
+    value,
+    maximum,
+    onChange,
+  }: {
+    value: number;
+    maximum: number;
+    onChange: (day: number) => void;
+  } = $props();
+
+  function handleInput(event: Event) {
+    const target = event.currentTarget as HTMLInputElement;
+    onChange(Math.abs(Number(target.value)));
+  }
+</script>
+
+<div>
+  <label
+    class="mb-2 block text-sm/6 font-medium text-gray-900"
+    for="day-slider"
+  >
+    Days before Finals
+  </label>
+  <input
+    oninput={handleInput}
+    class="w-full"
+    id="day-slider"
+    max="0"
+    min={-maximum}
+    step="1"
+    type="range"
+    value={-value}
+  />
+  <div class="flex justify-between">
+    <span class="text-sm text-gray-500">{maximum} days</span>
+    <span class="text-sm text-gray-500">Finals</span>
+  </div>
+</div>

--- a/src/lib/components/daily-rankings/DaySlider.svelte
+++ b/src/lib/components/daily-rankings/DaySlider.svelte
@@ -8,11 +8,6 @@
     maximum: number;
     onChange: (day: number) => void;
   } = $props();
-
-  function handleInput(event: Event) {
-    const target = event.currentTarget as HTMLInputElement;
-    onChange(Math.abs(Number(target.value)));
-  }
 </script>
 
 <div>
@@ -23,7 +18,7 @@
     Days before Finals
   </label>
   <input
-    oninput={handleInput}
+    oninput={(e) => onChange(Math.abs(Number(e.currentTarget.value)))}
     class="w-full"
     id="day-slider"
     max="0"

--- a/src/lib/components/daily-rankings/Table.svelte
+++ b/src/lib/components/daily-rankings/Table.svelte
@@ -1,0 +1,71 @@
+<script lang="ts">
+  import type { DailyRankingsItem } from '$lib/utils/daily-rankings';
+  import { ordinalSuffix } from '$lib/utils/ordinal';
+
+  let { rankings }: { rankings: DailyRankingsItem[] } = $props();
+</script>
+
+<table class="min-w-full divide-y divide-gray-300">
+  <thead class="bg-gray-50">
+    <tr>
+      <th
+        scope="col"
+        class="py-3.5 pr-3 pl-4 text-left text-sm font-semibold text-gray-900 sm:pl-6"
+      >
+        <span class="sr-only">Rank</span>
+      </th>
+      <th
+        scope="col"
+        class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+      >
+        Year
+      </th>
+      <th
+        scope="col"
+        class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell"
+      >
+        Score
+      </th>
+      <th
+        scope="col"
+        class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+      >
+        Location
+      </th>
+    </tr>
+  </thead>
+  <tbody class="divide-y divide-gray-200 bg-white">
+    {#each rankings as ranking (ranking.year)}
+      <tr>
+        <td
+          class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-gray-900 sm:pl-6"
+        >
+          {ranking.rank}{ordinalSuffix(ranking.rank)}
+        </td>
+        <td
+          class="px-3 py-4 text-sm font-medium whitespace-nowrap text-gray-900"
+        >
+          {ranking.year}
+          <dl class="font-normal md:hidden">
+            <dt class="sr-only">Score</dt>
+            <dd class="mt-1 truncate text-gray-500">{ranking.score}</dd>
+          </dl>
+        </td>
+        <td
+          class="hidden px-3 py-4 text-sm whitespace-nowrap text-gray-500 sm:table-cell"
+        >
+          {ranking.score}
+        </td>
+        <td class="px-3 py-4 text-sm whitespace-nowrap text-gray-500">
+          {ranking.location}
+          {#if ranking.daysOld}
+            <div class="text-gray-400">
+              {ranking.daysOld}
+              {ranking.daysOld === 1 ? 'day' : 'days'} prior
+            </div>
+          {/if}
+        </td>
+      </tr>
+    {/each}
+  </tbody>
+</table>

--- a/src/lib/components/nav/DesktopMenu.svelte
+++ b/src/lib/components/nav/DesktopMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
-  import type { NavItem } from './types.js';
+  import type { NavItem } from './types';
 
   let { navItems }: { navItems: ReadonlyArray<NavItem> } = $props();
 </script>

--- a/src/lib/components/nav/MobileMenu.svelte
+++ b/src/lib/components/nav/MobileMenu.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { resolve } from '$app/paths';
   import { page } from '$app/state';
-  import type { NavItem } from './types.js';
+  import type { NavItem } from './types';
 
   let {
     navItems,

--- a/src/lib/components/nav/MobileMenuToggle.svelte
+++ b/src/lib/components/nav/MobileMenuToggle.svelte
@@ -1,16 +1,11 @@
 <script lang="ts">
-  let {
-    isMobileMenuOpen,
-    setIsMobileMenuOpen,
-  }: {
-    isMobileMenuOpen: boolean;
-    setIsMobileMenuOpen: (value: boolean) => void;
-  } = $props();
+  let { isMobileMenuOpen = $bindable() }: { isMobileMenuOpen: boolean } =
+    $props();
 </script>
 
 <div class="-mr-2 flex md:hidden">
   <button
-    onclick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
+    onclick={() => (isMobileMenuOpen = !isMobileMenuOpen)}
     type="button"
     class="relative inline-flex items-center justify-center rounded-md bg-blue-600 p-2 text-blue-200 hover:bg-blue-500/75 hover:text-white focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-blue-600 focus:outline-hidden"
     aria-controls="mobile-menu"

--- a/src/lib/components/nav/NavigationBar.svelte
+++ b/src/lib/components/nav/NavigationBar.svelte
@@ -6,10 +6,6 @@
   import MobileMenuToggle from './MobileMenuToggle.svelte';
 
   let isMobileMenuOpen = $state(false);
-
-  function setIsMobileMenuOpen(value: boolean) {
-    isMobileMenuOpen = value;
-  }
 </script>
 
 <nav class="bg-blue-600">
@@ -19,14 +15,14 @@
         <Logo />
         <DesktopMenu navItems={NAV_ITEMS} />
       </div>
-      <MobileMenuToggle {isMobileMenuOpen} {setIsMobileMenuOpen} />
+      <MobileMenuToggle bind:isMobileMenuOpen />
     </div>
   </div>
 
   {#if isMobileMenuOpen}
     <MobileMenu
       navItems={NAV_ITEMS}
-      onNavigate={() => setIsMobileMenuOpen(false)}
+      onNavigate={() => (isMobileMenuOpen = false)}
     />
   {/if}
 </nav>

--- a/src/lib/components/nav/NavigationBar.svelte
+++ b/src/lib/components/nav/NavigationBar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { NAV_ITEMS } from './types.js';
+  import { NAV_ITEMS } from './types';
   import DesktopMenu from './DesktopMenu.svelte';
   import Logo from './Logo.svelte';
   import MobileMenu from './MobileMenu.svelte';

--- a/src/lib/components/shared/PageHeader.svelte
+++ b/src/lib/components/shared/PageHeader.svelte
@@ -21,9 +21,7 @@
       {/if}
     </div>
     <div>
-      {#if children}
-        {@render children()}
-      {/if}
+      {@render children?.()}
     </div>
   </div>
 </header>

--- a/src/lib/data/base.ts
+++ b/src/lib/data/base.ts
@@ -1,0 +1,12 @@
+export interface Score {
+  date: string;
+  location: string;
+  score: number;
+}
+
+export interface SeasonScores {
+  year: string;
+  color?: string;
+  endDate: string;
+  scores: Array<Score>;
+}

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -1,0 +1,95 @@
+import { type SeasonScores } from './base';
+
+import { SEASON_1977 } from './seasons/1977';
+import { SEASON_1978 } from './seasons/1978';
+import { SEASON_1980 } from './seasons/1980';
+import { SEASON_1981 } from './seasons/1981';
+import { SEASON_1982 } from './seasons/1982';
+import { SEASON_1984 } from './seasons/1984';
+import { SEASON_1985 } from './seasons/1985';
+import { SEASON_1986 } from './seasons/1986';
+import { SEASON_1987 } from './seasons/1987';
+import { SEASON_1988 } from './seasons/1988';
+import { SEASON_1989 } from './seasons/1989';
+import { SEASON_1990 } from './seasons/1990';
+import { SEASON_1991 } from './seasons/1991';
+import { SEASON_1992 } from './seasons/1992';
+import { SEASON_1993 } from './seasons/1993';
+import { SEASON_1994 } from './seasons/1994';
+import { SEASON_1995 } from './seasons/1995';
+import { SEASON_1996 } from './seasons/1996';
+import { SEASON_1997 } from './seasons/1997';
+import { SEASON_1998 } from './seasons/1998';
+import { SEASON_1999 } from './seasons/1999';
+import { SEASON_2000 } from './seasons/2000';
+import { SEASON_2001 } from './seasons/2001';
+import { SEASON_2002 } from './seasons/2002';
+import { SEASON_2003 } from './seasons/2003';
+import { SEASON_2004 } from './seasons/2004';
+import { SEASON_2005 } from './seasons/2005';
+import { SEASON_2006 } from './seasons/2006';
+import { SEASON_2007 } from './seasons/2007';
+import { SEASON_2008 } from './seasons/2008';
+import { SEASON_2009 } from './seasons/2009';
+import { SEASON_2010 } from './seasons/2010';
+import { SEASON_2011 } from './seasons/2011';
+import { SEASON_2012 } from './seasons/2012';
+import { SEASON_2013 } from './seasons/2013';
+import { SEASON_2014 } from './seasons/2014';
+import { SEASON_2015 } from './seasons/2015';
+import { SEASON_2016 } from './seasons/2016';
+import { SEASON_2017 } from './seasons/2017';
+import { SEASON_2018 } from './seasons/2018';
+import { SEASON_2019 } from './seasons/2019';
+import { SEASON_2022 } from './seasons/2022';
+import { SEASON_2023 } from './seasons/2023';
+import { SEASON_2024 } from './seasons/2024';
+import { SEASON_2025 } from './seasons/2025';
+
+export const ALL_SEASONS: SeasonScores[] = [
+  SEASON_1977,
+  SEASON_1978,
+  SEASON_1980,
+  SEASON_1981,
+  SEASON_1982,
+  SEASON_1984,
+  SEASON_1985,
+  SEASON_1986,
+  SEASON_1987,
+  SEASON_1988,
+  SEASON_1989,
+  SEASON_1990,
+  SEASON_1991,
+  SEASON_1992,
+  SEASON_1993,
+  SEASON_1994,
+  SEASON_1995,
+  SEASON_1996,
+  SEASON_1997,
+  SEASON_1998,
+  SEASON_1999,
+  SEASON_2000,
+  SEASON_2001,
+  SEASON_2002,
+  SEASON_2003,
+  SEASON_2004,
+  SEASON_2005,
+  SEASON_2006,
+  SEASON_2007,
+  SEASON_2008,
+  SEASON_2009,
+  SEASON_2010,
+  SEASON_2011,
+  SEASON_2012,
+  SEASON_2013,
+  SEASON_2014,
+  SEASON_2015,
+  SEASON_2016,
+  SEASON_2017,
+  SEASON_2018,
+  SEASON_2019,
+  SEASON_2022,
+  SEASON_2023,
+  SEASON_2024,
+  SEASON_2025,
+];

--- a/src/lib/data/seasons/1977.ts
+++ b/src/lib/data/seasons/1977.ts
@@ -1,0 +1,53 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1977: SeasonScores = {
+  year: '1977',
+  endDate: '1977-08-19',
+  scores: [
+    {
+      date: '1977-07-16',
+      location: 'Scarborough, ONT',
+      score: 65.5,
+    },
+    {
+      date: '1977-08-01',
+      location: 'Simcoe, ONT',
+      score: 66.25,
+    },
+    {
+      date: '1977-08-01',
+      location: 'North Tonawanda, NY',
+      score: 65.05,
+    },
+    {
+      date: '1977-08-01',
+      location: 'Simcoe, ONT',
+      score: 66.25,
+    },
+    {
+      date: '1977-08-03',
+      location: 'Bellefontaine, OH',
+      score: 68.7,
+    },
+    {
+      date: '1977-08-05',
+      location: 'Marion, OH',
+      score: 70.7,
+    },
+    {
+      date: '1977-08-10',
+      location: 'Butler, PA',
+      score: 65.2,
+    },
+    {
+      date: '1977-08-17',
+      location: 'Denver, CO',
+      score: 65.5,
+    },
+    // {
+    //   date: '1977-08-20',
+    //   location: 'Denver, CO',
+    //   score: 67.7,
+    // },
+  ],
+};

--- a/src/lib/data/seasons/1978.ts
+++ b/src/lib/data/seasons/1978.ts
@@ -1,0 +1,33 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1978: SeasonScores = {
+  year: '1978',
+  endDate: '1978-08-18',
+  scores: [
+    {
+      date: '1978-06-25',
+      location: 'Bellevue, OH',
+      score: 56.4,
+    },
+    {
+      date: '1978-07-02',
+      location: 'Columbus, OH',
+      score: 66.85,
+    },
+    {
+      date: '1978-07-14',
+      location: 'Cleveland, OH',
+      score: 62.25,
+    },
+    {
+      date: '1978-08-05',
+      location: 'Marion, OH',
+      score: 65.4,
+    },
+    {
+      date: '1978-08-16',
+      location: 'Denver, CO',
+      score: 68.5,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1980.ts
+++ b/src/lib/data/seasons/1980.ts
@@ -1,0 +1,33 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1980: SeasonScores = {
+  year: '1980',
+  endDate: '1980-08-16',
+  scores: [
+    {
+      date: '1980-07-09',
+      location: 'Columbus, OH',
+      score: 36.65,
+    },
+    {
+      date: '1980-08-01',
+      location: 'Marion, OH',
+      score: 52.75,
+    },
+    {
+      date: '1980-08-02',
+      location: 'Marion, OH',
+      score: 52.75,
+    },
+    {
+      date: '1980-08-06',
+      location: 'Butler, PA',
+      score: 47.9,
+    },
+    {
+      date: '1980-08-15',
+      location: 'Birmingham, AL',
+      score: 52.05,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1981.ts
+++ b/src/lib/data/seasons/1981.ts
@@ -1,0 +1,63 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1981: SeasonScores = {
+  year: '1981',
+  endDate: '1981-08-22',
+  scores: [
+    {
+      date: '1981-07-04',
+      location: 'Warren, PA',
+      score: 51.1,
+    },
+    {
+      date: '1981-07-18',
+      location: 'Titusville, PA',
+      score: 54.5,
+    },
+    {
+      date: '1981-08-04',
+      location: 'Toledo, OH',
+      score: 56.35,
+    },
+    {
+      date: '1981-08-04',
+      location: 'Toledo, OH',
+      score: 56.4,
+    },
+    {
+      date: '1981-08-08',
+      location: 'Whitewater, WI',
+      score: 58.95,
+    },
+    {
+      date: '1981-08-10',
+      location: 'Columbus, OH',
+      score: 54.7,
+    },
+    {
+      date: '1981-08-13',
+      location: 'Butler, PA',
+      score: 58.25,
+    },
+    {
+      date: '1981-08-14',
+      location: 'Ypsilanti, MI',
+      score: 61.1,
+    },
+    {
+      date: '1981-08-14',
+      location: 'Ypsilanti, MI',
+      score: 59.4,
+    },
+    {
+      date: '1981-08-18',
+      location: 'Philadelphia, PA',
+      score: 61.6,
+    },
+    {
+      date: '1981-08-21',
+      location: 'Montreal, QUE',
+      score: 59.6,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1982.ts
+++ b/src/lib/data/seasons/1982.ts
@@ -1,0 +1,53 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1982: SeasonScores = {
+  year: '1982',
+  endDate: '1982-08-21',
+  scores: [
+    {
+      date: '1982-06-19',
+      location: 'Cleveland, OH',
+      score: 71.2,
+    },
+    {
+      date: '1982-07-01',
+      location: 'Columbus, OH',
+      score: 47.0,
+    },
+    {
+      date: '1982-07-17',
+      location: 'Titusville, PA',
+      score: 67.6,
+    },
+    {
+      date: '1982-07-31',
+      location: 'Lynn, MA',
+      score: 47.6,
+    },
+    {
+      date: '1982-08-04',
+      location: 'Toledo, OH',
+      score: 50.4,
+    },
+    {
+      date: '1982-08-09',
+      location: 'Marion, OH',
+      score: 54.4,
+    },
+    {
+      date: '1982-08-12',
+      location: 'Canton, OH',
+      score: 52.2,
+    },
+    {
+      date: '1982-08-17',
+      location: 'Ogdensburg, NY',
+      score: 59.65,
+    },
+    {
+      date: '1982-08-20',
+      location: 'Montreal, QUE',
+      score: 56.25,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1984.ts
+++ b/src/lib/data/seasons/1984.ts
@@ -1,0 +1,63 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1984: SeasonScores = {
+  year: '1984',
+  endDate: '1984-08-18',
+  scores: [
+    {
+      date: '1984-06-23',
+      location: 'Berea, OH',
+      score: 44.5,
+    },
+    {
+      date: '1984-06-24',
+      location: 'Marion, OH',
+      score: 40,
+    },
+    {
+      date: '1984-06-28',
+      location: 'Canton, OH',
+      score: 38.8,
+    },
+    {
+      date: '1984-07-03',
+      location: 'Wheaton, IL',
+      score: 49.5,
+    },
+    {
+      date: '1984-07-04',
+      location: 'Champaign, IL',
+      score: 52.4,
+    },
+    {
+      date: '1984-07-28',
+      location: 'Sheffield, PA',
+      score: 69.2,
+    },
+    {
+      date: '1984-08-07',
+      location: 'Toledo, OH',
+      score: 56.8,
+    },
+    {
+      date: '1984-08-08',
+      location: 'Butler, PA',
+      score: 52.4,
+    },
+    {
+      date: '1984-08-11',
+      location: 'Alliance, OH',
+      score: 60.4,
+    },
+    {
+      date: '1984-08-15',
+      location: 'Atlanta, GA',
+      score: 65.9,
+    },
+    {
+      date: '1984-08-16',
+      location: 'Atlanta, GA',
+      score: 66.6,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1985.ts
+++ b/src/lib/data/seasons/1985.ts
@@ -1,0 +1,103 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1985: SeasonScores = {
+  year: '1985',
+  endDate: '1985-08-17',
+  scores: [
+    {
+      date: '1985-06-14',
+      location: 'Toledo, OH',
+      score: 61.3,
+    },
+    {
+      date: '1985-06-21',
+      location: 'Canton, OH',
+      score: 62.5,
+    },
+    {
+      date: '1985-06-22',
+      location: 'Berea, OH',
+      score: 63.1,
+    },
+    {
+      date: '1985-06-23',
+      location: 'Marion, OH',
+      score: 62.5,
+    },
+    {
+      date: '1985-06-29',
+      location: 'Durham, NC',
+      score: 45.5,
+    },
+    {
+      date: '1985-06-30',
+      location: 'Columbia, SC',
+      score: 44.2,
+    },
+    {
+      date: '1985-07-03',
+      location: 'Wheaton, IL',
+      score: 57.8,
+    },
+    {
+      date: '1985-07-04',
+      location: 'New Berlin, WI',
+      score: 60.5,
+    },
+    {
+      date: '1985-07-05',
+      location: 'Rolling Meadows, IL',
+      score: 61.9,
+    },
+    {
+      date: '1985-07-06',
+      location: 'Sandusky, OH',
+      score: 66.5,
+    },
+    {
+      date: '1985-07-13',
+      location: 'Whitewater, WI',
+      score: 61.4,
+    },
+    {
+      date: '1985-07-27',
+      location: 'Lynn, MA',
+      score: 59,
+    },
+    {
+      date: '1985-07-27',
+      location: 'Lynn, MA',
+      score: 62.4,
+    },
+    {
+      date: '1985-08-02',
+      location: 'Canton, OH',
+      score: 68,
+    },
+    {
+      date: '1985-08-08',
+      location: 'Canton, OH',
+      score: 60.8,
+    },
+    {
+      date: '1985-08-10',
+      location: 'Marion, OH',
+      score: 65.7,
+    },
+    {
+      date: '1985-08-11',
+      location: 'Toledo, OH',
+      score: 64.8,
+    },
+    {
+      date: '1985-08-14',
+      location: 'Madison, WI',
+      score: 67.3,
+    },
+    {
+      date: '1985-08-15',
+      location: 'Madison, WI',
+      score: 70.2,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1986.ts
+++ b/src/lib/data/seasons/1986.ts
@@ -1,0 +1,148 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1986: SeasonScores = {
+  year: '1986',
+  endDate: '1986-08-16',
+  scores: [
+    {
+      date: '1986-06-20',
+      location: 'Toledo, OH',
+      score: 58.5,
+    },
+    {
+      date: '1986-06-22',
+      location: 'Irwin, PA',
+      score: 55.6,
+    },
+    {
+      date: '1986-06-22',
+      location: 'Berea, OH',
+      score: 55.2,
+    },
+    {
+      date: '1986-06-24',
+      location: 'Canton, OH',
+      score: 58.1,
+    },
+    {
+      date: '1986-06-28',
+      location: 'Austintown, OH',
+      score: 65.1,
+    },
+    {
+      date: '1986-06-29',
+      location: 'Marion, OH',
+      score: 63.6,
+    },
+    {
+      date: '1986-06-30',
+      location: 'Windsor, ONT',
+      score: 70.8,
+    },
+    {
+      date: '1986-07-01',
+      location: 'Sarnia, ONT',
+      score: 69.3,
+    },
+    {
+      date: '1986-07-03',
+      location: 'Elmwood Park, IL',
+      score: 64.6,
+    },
+    {
+      date: '1986-07-04',
+      location: 'Franklin Park, IL',
+      score: 64.6,
+    },
+    {
+      date: '1986-07-06',
+      location: 'Saint Louis, MO',
+      score: 63.1,
+    },
+    {
+      date: '1986-07-19',
+      location: 'DeKalb, IL',
+      score: 74.1,
+    },
+    {
+      date: '1986-07-19',
+      location: 'DeKalb, IL',
+      score: 71.3,
+    },
+    {
+      date: '1986-07-20',
+      location: 'Terre Haute, IN',
+      score: 73.2,
+    },
+    {
+      date: '1986-07-22',
+      location: 'Columbus, OH',
+      score: 63.2,
+    },
+    {
+      date: '1986-07-23',
+      location: 'Cleveland, OH',
+      score: 63.6,
+    },
+    {
+      date: '1986-07-26',
+      location: 'Hamilton, ONT',
+      score: 72.2,
+    },
+    {
+      date: '1986-07-26',
+      location: 'Hamilton, ONT',
+      score: 70.2,
+    },
+    {
+      date: '1986-07-27',
+      location: 'Ypsilanti, MI',
+      score: 70.4,
+    },
+    {
+      date: '1986-07-29',
+      location: 'Parkersburg, WV',
+      score: 65.1,
+    },
+    {
+      date: '1986-08-02',
+      location: 'Warren, PA',
+      score: 79.3,
+    },
+    {
+      date: '1986-08-05',
+      location: 'Niles, OH',
+      score: 75.3,
+    },
+    {
+      date: '1986-08-09',
+      location: 'Marion, OH',
+      score: 77.4,
+    },
+    {
+      date: '1986-08-09',
+      location: 'Marion, OH',
+      score: 81.1,
+    },
+    {
+      date: '1986-08-10',
+      location: 'Port Huron, MI',
+      score: 73.8,
+    },
+    {
+      date: '1986-08-11',
+      location: 'Fort Wayne, IN',
+      score: 76.3,
+    },
+    {
+      date: '1986-08-14',
+      location: 'Madison, WI',
+      score: 83.1,
+    },
+    {
+      date: '1986-08-15',
+      location: 'Madison, WI',
+      score: 80.3,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1987.ts
+++ b/src/lib/data/seasons/1987.ts
@@ -1,0 +1,178 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1987: SeasonScores = {
+  year: '1987',
+  endDate: '1987-08-15',
+  scores: [
+    {
+      date: '1987-06-19',
+      location: 'Whitewater, WI',
+      score: 68.8,
+    },
+    {
+      date: '1987-06-20',
+      location: 'Milwaukee, WI',
+      score: 75.1,
+    },
+    {
+      date: '1987-06-21',
+      location: 'Normal, IL',
+      score: 72.5,
+    },
+    {
+      date: '1987-06-23',
+      location: 'Canton, OH',
+      score: 70.9,
+    },
+    {
+      date: '1987-06-24',
+      location: 'Cleveland, OH',
+      score: 74.7,
+    },
+    {
+      date: '1987-06-25',
+      location: 'Austintown, OH',
+      score: 70.9,
+    },
+    {
+      date: '1987-06-26',
+      location: 'Toledo, OH',
+      score: 73.29,
+    },
+    {
+      date: '1987-06-27',
+      location: 'Saginaw, MI',
+      score: 73.3,
+    },
+    {
+      date: '1987-06-29',
+      location: 'Terre Haute, IN',
+      score: 74.1,
+    },
+    {
+      date: '1987-06-30',
+      location: 'Windsor, ONT',
+      score: 76.5,
+    },
+    {
+      date: '1987-07-02',
+      location: 'Streator, IL',
+      score: 78.4,
+    },
+    {
+      date: '1987-07-03',
+      location: 'Rockford, IL',
+      score: 80.1,
+    },
+    {
+      date: '1987-07-04',
+      location: 'Elmwood Park, IL',
+      score: 81.2,
+    },
+    {
+      date: '1987-07-17',
+      location: 'Sun Prairie, WI',
+      score: 76.7,
+    },
+    {
+      date: '1987-07-18',
+      location: 'DeKalb, IL',
+      score: 77.9,
+    },
+    {
+      date: '1987-07-18',
+      location: 'DeKalb, IL',
+      score: 80.5,
+    },
+    {
+      date: '1987-07-20',
+      location: 'Parma, OH',
+      score: 78.05,
+    },
+    {
+      date: '1987-07-21',
+      location: 'Cincinnati, OH',
+      score: 77,
+    },
+    {
+      date: '1987-07-23',
+      location: 'Fort Wayne, IN',
+      score: 80.8,
+    },
+    {
+      date: '1987-07-24',
+      location: 'Ypsilanti, MI',
+      score: 79.4,
+    },
+    {
+      date: '1987-07-25',
+      location: 'Hamilton, ONT',
+      score: 82.5,
+    },
+    {
+      date: '1987-07-25',
+      location: 'Hamilton, ONT',
+      score: 83.1,
+    },
+    {
+      date: '1987-07-27',
+      location: 'Vincent, OH',
+      score: 82.7,
+    },
+    {
+      date: '1987-07-29',
+      location: 'Columbus, OH',
+      score: 83.8,
+    },
+    {
+      date: '1987-07-30',
+      location: 'Evansville, IN',
+      score: 82.9,
+    },
+    {
+      date: '1987-08-01',
+      location: 'Birmingham, AL',
+      score: 81,
+    },
+    {
+      date: '1987-08-01',
+      location: 'Birmingham, AL',
+      score: 84.3,
+    },
+    {
+      date: '1987-08-03',
+      location: 'Jonesboro, AR',
+      score: 81.3,
+    },
+    {
+      date: '1987-08-08',
+      location: 'Marion, OH',
+      score: 85.8,
+    },
+    {
+      date: '1987-08-08',
+      location: 'Marion, OH',
+      score: 87.4,
+    },
+    {
+      date: '1987-08-10',
+      location: 'Port Huron, MI',
+      score: 87,
+    },
+    {
+      date: '1987-08-13',
+      location: 'Madison, WI',
+      score: 86.2,
+    },
+    {
+      date: '1987-08-14',
+      location: 'Madison, WI',
+      score: 89,
+    },
+    {
+      date: '1987-08-15',
+      location: 'Madison, WI',
+      score: 85.7,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1988.ts
+++ b/src/lib/data/seasons/1988.ts
@@ -1,0 +1,193 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1988: SeasonScores = {
+  year: '1988',
+  endDate: '1988-08-20',
+  scores: [
+    {
+      date: '1988-06-17',
+      location: 'Whitewater, WI',
+      score: 65.5,
+    },
+    {
+      date: '1988-06-18',
+      location: 'Palatine, IL',
+      score: 69.6,
+    },
+    {
+      date: '1988-06-19',
+      location: 'Normal, IL',
+      score: 63.8,
+    },
+    {
+      date: '1988-06-20',
+      location: 'Mishawaka, IN',
+      score: 66.6,
+    },
+    {
+      date: '1988-06-21',
+      location: 'Saginaw, MI',
+      score: 69,
+    },
+    {
+      date: '1988-06-23',
+      location: 'Toledo, OH',
+      score: 67.8,
+    },
+    {
+      date: '1988-06-24',
+      location: 'Milwaukee, WI',
+      score: 62.7,
+    },
+    {
+      date: '1988-06-26',
+      location: 'Goshen, IN',
+      score: 71.7,
+    },
+    {
+      date: '1988-06-27',
+      location: 'Youngstown, OH',
+      score: 72,
+    },
+    {
+      date: '1988-06-28',
+      location: 'Canton, OH',
+      score: 75,
+    },
+    {
+      date: '1988-07-01',
+      location: 'Greensburg, PA',
+      score: 71.9,
+    },
+    {
+      date: '1988-07-02',
+      location: 'Hershey, PA',
+      score: 72.3,
+    },
+    {
+      date: '1988-07-05',
+      location: 'Cary, NC',
+      score: 71.1,
+    },
+    {
+      date: '1988-07-07',
+      location: 'Salem, VA',
+      score: 70,
+    },
+    {
+      date: '1988-07-08',
+      location: 'Midlothian, VA',
+      score: 74.3,
+    },
+    {
+      date: '1988-07-10',
+      location: 'Hanover, PA',
+      score: 74.8,
+    },
+    {
+      date: '1988-07-15',
+      location: 'DeKalb, IL',
+      score: 77.8,
+    },
+    {
+      date: '1988-07-16',
+      location: 'DeKalb, IL',
+      score: 78.3,
+    },
+    {
+      date: '1988-07-26',
+      location: 'Erie, PA',
+      score: 79.9,
+    },
+    {
+      date: '1988-07-27',
+      location: 'Perry Township, OH',
+      score: 80.2,
+    },
+    {
+      date: '1988-07-28',
+      location: 'Bellevue, OH',
+      score: 82.7,
+    },
+    {
+      date: '1988-07-30',
+      location: 'Hamilton, ONT',
+      score: 82.7,
+    },
+    {
+      date: '1988-07-30',
+      location: 'Hamilton, ONT',
+      score: 83,
+    },
+    {
+      date: '1988-08-01',
+      location: 'Cleveland, OH',
+      score: 81.2,
+    },
+    {
+      date: '1988-08-03',
+      location: 'Morgantown, WV',
+      score: 83.8,
+    },
+    {
+      date: '1988-08-04',
+      location: 'West Chester, PA',
+      score: 85.4,
+    },
+    {
+      date: '1988-08-05',
+      location: 'Garfield, NJ',
+      score: 85,
+    },
+    {
+      date: '1988-08-06',
+      location: 'Allentown, PA',
+      score: 85.9,
+    },
+    {
+      date: '1988-08-06',
+      location: 'Allentown, PA',
+      score: 85.4,
+    },
+    {
+      date: '1988-08-08',
+      location: 'Vincent, OH',
+      score: 86.7,
+    },
+    {
+      date: '1988-08-09',
+      location: 'Columbus, OH',
+      score: 87.2,
+    },
+    {
+      date: '1988-08-10',
+      location: 'Bloomington, IN',
+      score: 87.6,
+    },
+    {
+      date: '1988-08-12',
+      location: 'Des Plaines, IL',
+      score: 87.1,
+    },
+    {
+      date: '1988-08-13',
+      location: 'Saint Louis, MO',
+      score: 88.4,
+    },
+    {
+      date: '1988-08-15',
+      location: 'Omaha, NE',
+      score: 89.3,
+    },
+    {
+      date: '1988-08-19',
+      location: 'Kansas City, MO',
+      score: 88.6,
+    },
+    {
+      date: '1988-08-20',
+      location: 'Kansas City, MO',
+      score: 86.7,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1989.ts
+++ b/src/lib/data/seasons/1989.ts
@@ -1,0 +1,168 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1989: SeasonScores = {
+  year: '1989',
+  endDate: '1989-08-19',
+  scores: [
+    {
+      date: '1989-06-16',
+      location: 'Goshen, IN',
+      score: 63.7,
+    },
+    {
+      date: '1989-06-17',
+      location: 'Canton, OH',
+      score: 63.2,
+    },
+    {
+      date: '1989-06-18',
+      location: 'Youngstown, OH',
+      score: 63.5,
+    },
+    {
+      date: '1989-06-20',
+      location: 'Wyandotte, MI',
+      score: 68.1,
+    },
+    {
+      date: '1989-06-23',
+      location: 'Whitewater, WI',
+      score: 71.9,
+    },
+    {
+      date: '1989-06-24',
+      location: 'Milwaukee, WI',
+      score: 69.5,
+    },
+    {
+      date: '1989-06-25',
+      location: 'Green Bay, WI',
+      score: 69.2,
+    },
+    {
+      date: '1989-06-27',
+      location: 'Toledo, OH',
+      score: 68.7,
+    },
+    {
+      date: '1989-06-28',
+      location: 'Saginaw, MI',
+      score: 71,
+    },
+    {
+      date: '1989-06-30',
+      location: 'Morgantown, WV',
+      score: 70.2,
+    },
+    {
+      date: '1989-07-01',
+      location: 'Hershey, PA',
+      score: 72.7,
+    },
+    {
+      date: '1989-07-02',
+      location: 'Philadelphia, PA',
+      score: 71.7,
+    },
+    {
+      date: '1989-07-03',
+      location: 'Bristol, RI',
+      score: 69,
+    },
+    {
+      date: '1989-07-04',
+      location: 'Chelmsford, MA',
+      score: 72.7,
+    },
+    {
+      date: '1989-07-07',
+      location: 'Millersville, PA',
+      score: 67.4,
+    },
+    {
+      date: '1989-07-15',
+      location: 'DeKalb, IL',
+      score: 77.4,
+    },
+    {
+      date: '1989-07-15',
+      location: 'DeKalb, IL',
+      score: 79.5,
+    },
+    {
+      date: '1989-07-24',
+      location: 'Fort Edward, NY',
+      score: 76.7,
+    },
+    {
+      date: '1989-07-26',
+      location: 'Erie, PA',
+      score: 81.6,
+    },
+    {
+      date: '1989-07-27',
+      location: 'Columbus, OH',
+      score: 84.1,
+    },
+    {
+      date: '1989-07-29',
+      location: 'Bloomington, IN',
+      score: 82.6,
+    },
+    {
+      date: '1989-08-01',
+      location: 'Perry Township, OH',
+      score: 85.3,
+    },
+    {
+      date: '1989-08-06',
+      location: 'East Rutherford, NJ',
+      score: 86.7,
+    },
+    {
+      date: '1989-08-08',
+      location: 'Cleveland, OH',
+      score: 88.2,
+    },
+    {
+      date: '1989-08-09',
+      location: 'Fort Wayne, IN',
+      score: 91.5,
+    },
+    {
+      date: '1989-08-11',
+      location: 'Des Plaines, IL',
+      score: 88.8,
+    },
+    {
+      date: '1989-08-12',
+      location: 'Whitewater, WI',
+      score: 88.6,
+    },
+    {
+      date: '1989-08-12',
+      location: 'Whitewater, WI',
+      score: 86.7,
+    },
+    {
+      date: '1989-08-13',
+      location: 'Sparta, IL',
+      score: 88.4,
+    },
+    {
+      date: '1989-08-17',
+      location: 'Kansas City, MO',
+      score: 87,
+    },
+    {
+      date: '1989-08-18',
+      location: 'Kansas City, MO',
+      score: 90.3,
+    },
+    {
+      date: '1989-08-19',
+      location: 'Kansas City, MO',
+      score: 90.3,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1990.ts
+++ b/src/lib/data/seasons/1990.ts
@@ -1,0 +1,198 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1990: SeasonScores = {
+  year: '1990',
+  endDate: '1990-08-18',
+  scores: [
+    {
+      date: '1990-06-15',
+      location: 'Indianapolis, IN',
+      score: 67.8,
+    },
+    {
+      date: '1990-06-16',
+      location: 'Canton, OH',
+      score: 64.3,
+    },
+    {
+      date: '1990-06-17',
+      location: 'Wadsworth, OH',
+      score: 65.9,
+    },
+    {
+      date: '1990-06-18',
+      location: 'Columbus, OH',
+      score: 65.2,
+    },
+    {
+      date: '1990-06-19',
+      location: 'Port Clinton, OH',
+      score: 67.6,
+    },
+    {
+      date: '1990-06-20',
+      location: 'Wyandotte, MI',
+      score: 67.3,
+    },
+    {
+      date: '1990-06-22',
+      location: 'Milwaukee, WI',
+      score: 65,
+    },
+    {
+      date: '1990-06-23',
+      location: 'Whitewater, WI',
+      score: 67.1,
+    },
+    {
+      date: '1990-06-24',
+      location: 'Charleston, IL',
+      score: 68.9,
+    },
+    {
+      date: '1990-06-27',
+      location: 'Otsego, MI',
+      score: 71.4,
+    },
+    {
+      date: '1990-07-01',
+      location: 'Philadelphia, PA',
+      score: 72.6,
+    },
+    {
+      date: '1990-07-03',
+      location: 'Bristol, RI',
+      score: 74.9,
+    },
+    {
+      date: '1990-07-04',
+      location: 'Chelmsford, MA',
+      score: 74,
+    },
+    {
+      date: '1990-07-06',
+      location: 'Wilmington, DE',
+      score: 71.2,
+    },
+    {
+      date: '1990-07-07',
+      location: 'Hershey, PA',
+      score: 72.6,
+    },
+    {
+      date: '1990-07-14',
+      location: 'Madison, WI',
+      score: 77.4,
+    },
+    {
+      date: '1990-07-15',
+      location: 'Rockford, IL',
+      score: 76.2,
+    },
+    {
+      date: '1990-07-18',
+      location: 'Carbondale, IL',
+      score: 75.1,
+    },
+    {
+      date: '1990-07-20',
+      location: 'DeKalb, IL',
+      score: 78.3,
+    },
+    {
+      date: '1990-07-21',
+      location: 'DeKalb, IL',
+      score: 78.7,
+    },
+    {
+      date: '1990-07-23',
+      location: 'Omaha, NE',
+      score: 81.9,
+    },
+    {
+      date: '1990-07-24',
+      location: 'Ankeny, IA',
+      score: 81.6,
+    },
+    {
+      date: '1990-07-25',
+      location: 'Stillwater, MN',
+      score: 80.3,
+    },
+    {
+      date: '1990-07-28',
+      location: 'Whitewater, WI',
+      score: 80.5,
+    },
+    {
+      date: '1990-07-28',
+      location: 'Whitewater, WI',
+      score: 82.8,
+    },
+    {
+      date: '1990-07-30',
+      location: 'Columbus, OH',
+      score: 84.3,
+    },
+    {
+      date: '1990-07-31',
+      location: 'Canton, OH',
+      score: 83.1,
+    },
+    {
+      date: '1990-08-02',
+      location: 'Erie, PA',
+      score: 80.1,
+    },
+    {
+      date: '1990-08-05',
+      location: 'Port Clinton, OH',
+      score: 83.6,
+    },
+    {
+      date: '1990-08-07',
+      location: 'Centerville, OH',
+      score: 84.6,
+    },
+    {
+      date: '1990-08-08',
+      location: 'Cincinnati, OH',
+      score: 85.1,
+    },
+    {
+      date: '1990-08-09',
+      location: 'Marion, OH',
+      score: 86.7,
+    },
+    {
+      date: '1990-08-11',
+      location: 'Bloomington, IN',
+      score: 86.5,
+    },
+    {
+      date: '1990-08-12',
+      location: 'Bellevue, OH',
+      score: 86.6,
+    },
+    {
+      date: '1990-08-13',
+      location: 'Hornell, NY',
+      score: 88.2,
+    },
+    {
+      date: '1990-08-16',
+      location: 'Buffalo, NY',
+      score: 90.3,
+    },
+    {
+      date: '1990-08-17',
+      location: 'Buffalo, NY',
+      score: 90.3,
+    },
+    {
+      date: '1990-08-18',
+      location: 'Buffalo, NY',
+      score: 89.2,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1991.ts
+++ b/src/lib/data/seasons/1991.ts
@@ -1,0 +1,188 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1991: SeasonScores = {
+  year: '1991',
+  endDate: '1991-08-17',
+  scores: [
+    {
+      date: '1991-06-15',
+      location: 'Canton, OH',
+      score: 64.9,
+    },
+    {
+      date: '1991-06-17',
+      location: 'Columbus, OH',
+      score: 63.7,
+    },
+    {
+      date: '1991-06-20',
+      location: 'Wyandotte, MI',
+      score: 67.3,
+    },
+    {
+      date: '1991-06-21',
+      location: 'Whitewater, WI',
+      score: 66.5,
+    },
+    {
+      date: '1991-06-22',
+      location: 'Milwaukee, WI',
+      score: 66.9,
+    },
+    {
+      date: '1991-06-23',
+      location: 'Normal, IL',
+      score: 69.7,
+    },
+    {
+      date: '1991-06-25',
+      location: 'Saginaw, MI',
+      score: 68.8,
+    },
+    {
+      date: '1991-06-26',
+      location: 'Otsego, MI',
+      score: 71.7,
+    },
+    {
+      date: '1991-06-28',
+      location: 'Mishawaka, IN',
+      score: 69.7,
+    },
+    {
+      date: '1991-06-29',
+      location: 'Charleston, IL',
+      score: 71.9,
+    },
+    {
+      date: '1991-07-05',
+      location: 'Bensalem, PA',
+      score: 66.7,
+    },
+    {
+      date: '1991-07-06',
+      location: 'Hershey, PA',
+      score: 71.6,
+    },
+    {
+      date: '1991-07-12',
+      location: 'Madison, WI',
+      score: 77.1,
+    },
+    {
+      date: '1991-07-13',
+      location: 'Rockford, IL',
+      score: 76.5,
+    },
+    {
+      date: '1991-07-14',
+      location: 'Dubuque, IA',
+      score: 79.2,
+    },
+    {
+      date: '1991-07-19',
+      location: 'Toledo, OH',
+      score: 76.6,
+    },
+    {
+      date: '1991-07-20',
+      location: 'Toledo, OH',
+      score: 76.6,
+    },
+    {
+      date: '1991-07-23',
+      location: 'Morgantown, WV',
+      score: 76.4,
+    },
+    {
+      date: '1991-07-24',
+      location: 'Canton, OH',
+      score: 78,
+    },
+    {
+      date: '1991-07-25',
+      location: 'Plymouth, MI',
+      score: 78.9,
+    },
+    {
+      date: '1991-07-27',
+      location: 'Madison, WI',
+      score: 80.3,
+    },
+    {
+      date: '1991-07-27',
+      location: 'Madison, WI',
+      score: 78.9,
+    },
+    {
+      date: '1991-07-29',
+      location: 'Fort Wayne, IN',
+      score: 81.8,
+    },
+    {
+      date: '1991-07-31',
+      location: 'Dublin, OH',
+      score: 83.1,
+    },
+    {
+      date: '1991-08-01',
+      location: 'Port Huron, MI',
+      score: 79.2,
+    },
+    {
+      date: '1991-08-03',
+      location: 'Hamilton, ONT',
+      score: 83.2,
+    },
+    {
+      date: '1991-08-03',
+      location: 'Hamilton, ONT',
+      score: 83.3,
+    },
+    {
+      date: '1991-08-05',
+      location: 'Parma, OH',
+      score: 85.6,
+    },
+    {
+      date: '1991-08-07',
+      location: 'Hornell, NY',
+      score: 84.3,
+    },
+    {
+      date: '1991-08-09',
+      location: 'Marion, OH',
+      score: 86.7,
+    },
+    {
+      date: '1991-08-10',
+      location: 'Bloomington, IN',
+      score: 86.4,
+    },
+    {
+      date: '1991-08-11',
+      location: 'Lawrence, KS',
+      score: 83.1,
+    },
+    {
+      date: '1991-08-12',
+      location: 'Tulsa, OK',
+      score: 85.9,
+    },
+    {
+      date: '1991-08-15',
+      location: 'Dallas, TX',
+      score: 86.9,
+    },
+    {
+      date: '1991-08-16',
+      location: 'Dallas, TX',
+      score: 87,
+    },
+    {
+      date: '1991-08-17',
+      location: 'Dallas, TX',
+      score: 84.4,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1992.ts
+++ b/src/lib/data/seasons/1992.ts
@@ -1,0 +1,188 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1992: SeasonScores = {
+  year: '1992',
+  endDate: '1992-08-15',
+  scores: [
+    {
+      date: '1992-06-13',
+      location: 'Normal, IL',
+      score: 62.1,
+    },
+    {
+      date: '1992-06-14',
+      location: 'La Porte, IN',
+      score: 63.4,
+    },
+    {
+      date: '1992-06-15',
+      location: 'Mansfield, OH',
+      score: 62.1,
+    },
+    {
+      date: '1992-06-16',
+      location: 'Wyandotte, MI',
+      score: 61.8,
+    },
+    {
+      date: '1992-06-19',
+      location: 'DeKalb, IL',
+      score: 60.7,
+    },
+    {
+      date: '1992-06-20',
+      location: 'Charleston, IL',
+      score: 64.9,
+    },
+    {
+      date: '1992-06-22',
+      location: 'Canton, MI',
+      score: 68.2,
+    },
+    {
+      date: '1992-06-25',
+      location: 'Pittsburgh, PA',
+      score: 65.5,
+    },
+    {
+      date: '1992-06-26',
+      location: 'Indianapolis, IN',
+      score: 65.5,
+    },
+    {
+      date: '1992-06-27',
+      location: 'Massillon, OH',
+      score: 66,
+    },
+    {
+      date: '1992-06-29',
+      location: 'Hilliard, OH',
+      score: 65.9,
+    },
+    {
+      date: '1992-07-11',
+      location: 'Hershey, PA',
+      score: 69,
+    },
+    {
+      date: '1992-07-13',
+      location: 'Kannapolis, NC',
+      score: 71,
+    },
+    {
+      date: '1992-07-14',
+      location: 'Richmond, VA',
+      score: 68.5,
+    },
+    {
+      date: '1992-07-17',
+      location: 'Toledo, OH',
+      score: 73.8,
+    },
+    {
+      date: '1992-07-18',
+      location: 'Toledo, OH',
+      score: 73.5,
+    },
+    {
+      date: '1992-07-19',
+      location: 'Buffalo, NY',
+      score: 72.7,
+    },
+    {
+      date: '1992-07-21',
+      location: 'Bellevue, OH',
+      score: 71.2,
+    },
+    {
+      date: '1992-07-22',
+      location: 'Centerville, OH',
+      score: 71.5,
+    },
+    {
+      date: '1992-07-24',
+      location: 'Nashville, TN',
+      score: 78,
+    },
+    {
+      date: '1992-07-25',
+      location: 'Nashville, TN',
+      score: 76,
+    },
+    {
+      date: '1992-07-26',
+      location: 'Alexandria, KY',
+      score: 77.1,
+    },
+    {
+      date: '1992-07-28',
+      location: 'Canton, OH',
+      score: 79.9,
+    },
+    {
+      date: '1992-07-29',
+      location: 'Endicott, NY',
+      score: 80,
+    },
+    {
+      date: '1992-07-30',
+      location: 'East Rutherford, NJ',
+      score: 81,
+    },
+    {
+      date: '1992-08-01',
+      location: 'Allentown, PA',
+      score: 79.1,
+    },
+    {
+      date: '1992-08-01',
+      location: 'Allentown, PA',
+      score: 80.6,
+    },
+    {
+      date: '1992-08-02',
+      location: 'Fort Edward, NY',
+      score: 81.9,
+    },
+    {
+      date: '1992-08-04',
+      location: 'Montreal, QUE',
+      score: 79.7,
+    },
+    {
+      date: '1992-08-05',
+      location: 'Rome, NY',
+      score: 83.8,
+    },
+    {
+      date: '1992-08-06',
+      location: 'Cleveland, OH',
+      score: 83.2,
+    },
+    {
+      date: '1992-08-08',
+      location: 'Bloomington, IN',
+      score: 80.7,
+    },
+    {
+      date: '1992-08-09',
+      location: 'South Milwaukee, WI',
+      score: 85.7,
+    },
+    {
+      date: '1992-08-13',
+      location: 'Madison, WI',
+      score: 85.6,
+    },
+    {
+      date: '1992-08-14',
+      location: 'Madison, WI',
+      score: 85.5,
+    },
+    {
+      date: '1992-08-15',
+      location: 'Madison, WI',
+      score: 84.6,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1993.ts
+++ b/src/lib/data/seasons/1993.ts
@@ -1,0 +1,183 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1993: SeasonScores = {
+  year: '1993',
+  endDate: '1993-08-21',
+  scores: [
+    {
+      date: '1993-06-20',
+      location: 'Toledo, OH',
+      score: 59.8,
+    },
+    {
+      date: '1993-06-21',
+      location: 'Mansfield, OH',
+      score: 61.2,
+    },
+    {
+      date: '1993-06-24',
+      location: 'Massillon, OH',
+      score: 62.9,
+    },
+    {
+      date: '1993-06-26',
+      location: 'Monmouth, IL',
+      score: 70.6,
+    },
+    {
+      date: '1993-06-27',
+      location: 'La Porte, IN',
+      score: 64.7,
+    },
+    {
+      date: '1993-06-30',
+      location: 'Bellevue, NE',
+      score: 67.4,
+    },
+    {
+      date: '1993-07-02',
+      location: 'Cedar Rapids, IA',
+      score: 69.2,
+    },
+    {
+      date: '1993-07-03',
+      location: 'Mount Prospect, IL',
+      score: 68.8,
+    },
+    {
+      date: '1993-07-09',
+      location: 'Norristown, PA',
+      score: 72.7,
+    },
+    {
+      date: '1993-07-10',
+      location: 'Hershey, PA',
+      score: 70.8,
+    },
+    {
+      date: '1993-07-11',
+      location: 'Charleston, WV',
+      score: 72.9,
+    },
+    {
+      date: '1993-07-16',
+      location: 'Toledo, OH',
+      score: 72.6,
+    },
+    {
+      date: '1993-07-17',
+      location: 'Toledo, OH',
+      score: 71.1,
+    },
+    {
+      date: '1993-07-20',
+      location: 'Montreal, QUE',
+      score: 73.7,
+    },
+    {
+      date: '1993-07-21',
+      location: 'Pittsfield, MA',
+      score: 73.2,
+    },
+    {
+      date: '1993-07-22',
+      location: 'East Rutherford, NJ',
+      score: 75.9,
+    },
+    {
+      date: '1993-07-24',
+      location: 'Buffalo, NY',
+      score: 76.5,
+    },
+    {
+      date: '1993-07-25',
+      location: 'Endicott, NY',
+      score: 76.7,
+    },
+    {
+      date: '1993-07-26',
+      location: 'Massillon, OH',
+      score: 77.1,
+    },
+    {
+      date: '1993-07-28',
+      location: 'Fort Wayne, IN',
+      score: 77.6,
+    },
+    {
+      date: '1993-07-30',
+      location: 'Ypsilanti, MI',
+      score: 76.9,
+    },
+    {
+      date: '1993-07-31',
+      location: 'Ypsilanti, MI',
+      score: 77.1,
+    },
+    {
+      date: '1993-08-02',
+      location: 'Mentor, OH',
+      score: 79.6,
+    },
+    {
+      date: '1993-08-03',
+      location: 'Salem, VA',
+      score: 80.6,
+    },
+    {
+      date: '1993-08-05',
+      location: 'Bensalem, PA',
+      score: 80.2,
+    },
+    {
+      date: '1993-08-07',
+      location: 'Allentown, PA',
+      score: 83.1,
+    },
+    {
+      date: '1993-08-07',
+      location: 'Allentown, PA',
+      score: 84.8,
+    },
+    {
+      date: '1993-08-08',
+      location: 'Hampton, VA',
+      score: 84.2,
+    },
+    {
+      date: '1993-08-09',
+      location: 'Charlotte, NC',
+      score: 86,
+    },
+    {
+      date: '1993-08-10',
+      location: 'Winston-Salem, NC',
+      score: 84.6,
+    },
+    {
+      date: '1993-08-13',
+      location: 'Marion, OH',
+      score: 88.2,
+    },
+    {
+      date: '1993-08-14',
+      location: 'Bloomington, IN',
+      score: 87.3,
+    },
+    {
+      date: '1993-08-19',
+      location: 'Jackson, MS',
+      score: 88.3,
+    },
+    {
+      date: '1993-08-20',
+      location: 'Jackson, MS',
+      score: 88,
+    },
+    {
+      date: '1993-08-21',
+      location: 'Jackson, MS',
+      score: 87.2,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1994.ts
+++ b/src/lib/data/seasons/1994.ts
@@ -1,0 +1,158 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1994: SeasonScores = {
+  year: '1994',
+  endDate: '1994-08-19',
+  scores: [
+    {
+      date: '1994-06-21',
+      location: 'Otsego, MI',
+      score: 59,
+    },
+    {
+      date: '1994-06-23',
+      location: 'Dayton, OH',
+      score: 62.1,
+    },
+    {
+      date: '1994-06-24',
+      location: 'Winchester, KY',
+      score: 62.4,
+    },
+    {
+      date: '1994-06-28',
+      location: 'Pittsburgh, PA',
+      score: 60.8,
+    },
+    {
+      date: '1994-06-29',
+      location: 'Charleston, WV',
+      score: 62.6,
+    },
+    {
+      date: '1994-07-02',
+      location: 'Clifton, NJ',
+      score: 67,
+    },
+    {
+      date: '1994-07-03',
+      location: 'Bristol, RI',
+      score: 66.8,
+    },
+    {
+      date: '1994-07-04',
+      location: 'Wakefield, MA',
+      score: 68.5,
+    },
+    {
+      date: '1994-07-07',
+      location: 'Syracuse, NY',
+      score: 75.8,
+    },
+    {
+      date: '1994-07-08',
+      location: 'Kingston, NY',
+      score: 65.4,
+    },
+    {
+      date: '1994-07-09',
+      location: 'Boston, MA',
+      score: 68.4,
+    },
+    {
+      date: '1994-07-16',
+      location: 'Hershey, PA',
+      score: 71,
+    },
+    {
+      date: '1994-07-17',
+      location: 'Columbus, OH',
+      score: 71.4,
+    },
+    {
+      date: '1994-07-19',
+      location: 'Evansville, IN',
+      score: 71.4,
+    },
+    {
+      date: '1994-07-21',
+      location: 'Fairfield, OH',
+      score: 74.8,
+    },
+    {
+      date: '1994-07-22',
+      location: 'Sevierville, TN',
+      score: 76.8,
+    },
+    {
+      date: '1994-07-23',
+      location: 'Nashville, TN',
+      score: 74.6,
+    },
+    {
+      date: '1994-07-29',
+      location: 'Madison, WI',
+      score: 77.7,
+    },
+    {
+      date: '1994-07-30',
+      location: 'Madison, WI',
+      score: 77.5,
+    },
+    {
+      date: '1994-08-02',
+      location: 'Ypsilanti, MI',
+      score: 79,
+    },
+    {
+      date: '1994-08-03',
+      location: 'Centerville, OH',
+      score: 80.3,
+    },
+    {
+      date: '1994-08-06',
+      location: 'Canton, OH',
+      score: 80.2,
+    },
+    {
+      date: '1994-08-08',
+      location: 'Huntington, WV',
+      score: 79.7,
+    },
+    {
+      date: '1994-08-10',
+      location: 'Bellevue, OH',
+      score: 80.6,
+    },
+    {
+      date: '1994-08-11',
+      location: 'Glens Falls, NY',
+      score: 83,
+    },
+    {
+      date: '1994-08-12',
+      location: 'Montreal, QUE',
+      score: 82.9,
+    },
+    {
+      date: '1994-08-15',
+      location: 'Rome, NY',
+      score: 83.9,
+    },
+    {
+      date: '1994-08-17',
+      location: 'Boston, MA',
+      score: 84.1,
+    },
+    {
+      date: '1994-08-18',
+      location: 'Boston, MA',
+      score: 84.1,
+    },
+    {
+      date: '1994-08-19',
+      location: 'Boston, MA',
+      score: 84.3,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1995.ts
+++ b/src/lib/data/seasons/1995.ts
@@ -1,0 +1,133 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1995: SeasonScores = {
+  year: '1995',
+  endDate: '1995-08-12',
+  scores: [
+    {
+      date: '1995-07-01',
+      location: 'Hershey, PA',
+      score: 63.7,
+    },
+    {
+      date: '1995-07-02',
+      location: 'Clifton, NJ',
+      score: 67.3,
+    },
+    {
+      date: '1995-07-03',
+      location: 'Bristol, RI',
+      score: 70.6,
+    },
+    {
+      date: '1995-07-07',
+      location: 'Elkton, MD',
+      score: 70.6,
+    },
+    {
+      date: '1995-07-08',
+      location: 'Allentown, PA',
+      score: 71.9,
+    },
+    {
+      date: '1995-07-09',
+      location: 'Cherry Hill, NJ',
+      score: 73.7,
+    },
+    {
+      date: '1995-07-15',
+      location: 'Chattanooga, TN',
+      score: 75.2,
+    },
+    {
+      date: '1995-07-17',
+      location: 'Hopkinsville, KY',
+      score: 77.9,
+    },
+    {
+      date: '1995-07-18',
+      location: 'Sevierville, TN',
+      score: 77.3,
+    },
+    {
+      date: '1995-07-20',
+      location: 'Winston-Salem, NC',
+      score: 82.5,
+    },
+    {
+      date: '1995-07-22',
+      location: 'Massillon, OH',
+      score: 80.1,
+    },
+    {
+      date: '1995-07-24',
+      location: 'Erie, PA',
+      score: 77.7,
+    },
+    {
+      date: '1995-07-25',
+      location: 'Hornell, NY',
+      score: 82.3,
+    },
+    {
+      date: '1995-07-26',
+      location: 'Rome, NY',
+      score: 81,
+    },
+    {
+      date: '1995-07-28',
+      location: 'Ypsilanti, MI',
+      score: 83.4,
+    },
+    {
+      date: '1995-07-29',
+      location: 'Ypsilanti, MI',
+      score: 85,
+    },
+    {
+      date: '1995-07-31',
+      location: 'Huntington, WV',
+      score: 84.8,
+    },
+    {
+      date: '1995-08-01',
+      location: 'Atlanta, GA',
+      score: 84.6,
+    },
+    {
+      date: '1995-08-02',
+      location: 'Jacksonville, AL',
+      score: 84.7,
+    },
+    {
+      date: '1995-08-05',
+      location: 'Champaign, IL',
+      score: 86.9,
+    },
+    {
+      date: '1995-08-06',
+      location: 'Ft. Wayne, IN',
+      score: 84.9,
+    },
+    {
+      date: '1995-08-07',
+      location: 'Marion, OH',
+      score: 87.6,
+    },
+    {
+      date: '1995-08-10',
+      location: 'Buffalo, NY',
+      score: 88.7,
+    },
+    {
+      date: '1995-08-11',
+      location: 'Buffalo, NY',
+      score: 89.4,
+    },
+    {
+      date: '1995-08-12',
+      location: 'Buffalo, NY',
+      score: 89.5,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1996.ts
+++ b/src/lib/data/seasons/1996.ts
@@ -1,0 +1,133 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1996: SeasonScores = {
+  year: '1996',
+  endDate: '1996-08-17',
+  scores: [
+    {
+      date: '1996-06-28',
+      location: 'Butler, PA',
+      score: 66.1,
+    },
+    {
+      date: '1996-06-29',
+      location: 'Newark, DE',
+      score: 69.2,
+    },
+    {
+      date: '1996-06-30',
+      location: 'Lynn, MA',
+      score: 72,
+    },
+    {
+      date: '1996-07-03',
+      location: 'Bristol, RI',
+      score: 69.9,
+    },
+    {
+      date: '1996-07-05',
+      location: 'Kingston, NY',
+      score: 72.5,
+    },
+    {
+      date: '1996-07-08',
+      location: 'Montreal, QUE',
+      score: 74.8,
+    },
+    {
+      date: '1996-07-10',
+      location: 'Corning, NY',
+      score: 75.3,
+    },
+    {
+      date: '1996-07-13',
+      location: 'Allentown, PA',
+      score: 75,
+    },
+    {
+      date: '1996-07-16',
+      location: 'Dayton, OH',
+      score: 76.7,
+    },
+    {
+      date: '1996-07-21',
+      location: 'La Crosse, WI',
+      score: 80.6,
+    },
+    {
+      date: '1996-07-23',
+      location: 'Sioux City, IA',
+      score: 76.4,
+    },
+    {
+      date: '1996-07-25',
+      location: 'Stillwater, MN',
+      score: 79.1,
+    },
+    {
+      date: '1996-07-27',
+      location: 'Madison, WI',
+      score: 80.8,
+    },
+    {
+      date: '1996-07-28',
+      location: 'Ypsilanti, MI',
+      score: 80.9,
+    },
+    {
+      date: '1996-07-29',
+      location: 'Marion, OH',
+      score: 80.3,
+    },
+    {
+      date: '1996-07-31',
+      location: 'Massilon, OH',
+      score: 83,
+    },
+    {
+      date: '1996-08-02',
+      location: 'Allentown, PA',
+      score: 81,
+    },
+    {
+      date: '1996-08-05',
+      location: 'Fort Edward, NY',
+      score: 83.7,
+    },
+    {
+      date: '1996-08-06',
+      location: 'Hornell, NY',
+      score: 85.7,
+    },
+    {
+      date: '1996-08-07',
+      location: 'Columbus, OH',
+      score: 85.5,
+    },
+    {
+      date: '1996-08-09',
+      location: 'Salem, VA',
+      score: 83.7,
+    },
+    {
+      date: '1996-08-10',
+      location: 'Atlanta, GA',
+      score: 84.5,
+    },
+    {
+      date: '1996-08-15',
+      location: 'Orlando, FL',
+      score: 87.4,
+    },
+    {
+      date: '1996-08-16',
+      location: 'Orlando, FL',
+      score: 88.1,
+    },
+    {
+      date: '1996-08-17',
+      location: 'Orlando, FL',
+      score: 86.3,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1997.ts
+++ b/src/lib/data/seasons/1997.ts
@@ -1,0 +1,138 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1997: SeasonScores = {
+  year: '1997',
+  endDate: '1997-08-16',
+  scores: [
+    {
+      date: '1997-06-23',
+      location: 'Columbus, OH',
+      score: 67.1,
+    },
+    {
+      date: '1997-06-27',
+      location: 'Durham, NC',
+      score: 69,
+    },
+    {
+      date: '1997-06-28',
+      location: 'Wilmington, DE',
+      score: 69.1,
+    },
+    {
+      date: '1997-07-03',
+      location: 'Bristol, RI',
+      score: 75.5,
+    },
+    {
+      date: '1997-07-05',
+      location: 'Clifton, NJ',
+      score: 77.2,
+    },
+    {
+      date: '1997-07-06',
+      location: 'Audubon, NJ',
+      score: 77.1,
+    },
+    {
+      date: '1997-07-07',
+      location: 'Kingston, NY',
+      score: 76.2,
+    },
+    {
+      date: '1997-07-09',
+      location: 'Buffalo, NY',
+      score: 78,
+    },
+    {
+      date: '1997-07-10',
+      location: 'Butler, PA',
+      score: 77.7,
+    },
+    {
+      date: '1997-07-12',
+      location: 'Hershey, PA',
+      score: 80,
+    },
+    {
+      date: '1997-07-13',
+      location: 'Dayton, OH',
+      score: 80,
+    },
+    {
+      date: '1997-07-21',
+      location: 'Omaha, NE',
+      score: 78,
+    },
+    {
+      date: '1997-07-22',
+      location: 'Sioux City, IA',
+      score: 80.6,
+    },
+    {
+      date: '1997-07-23',
+      location: 'Stillwater, MN',
+      score: 79.2,
+    },
+    {
+      date: '1997-07-25',
+      location: 'Whitewater, WI',
+      score: 82.9,
+    },
+    {
+      date: '1997-07-27',
+      location: 'Ypsilanti, MI',
+      score: 82.1,
+    },
+    {
+      date: '1997-07-29',
+      location: 'Cincinnati, OH',
+      score: 83.5,
+    },
+    {
+      date: '1997-07-30',
+      location: 'Canton, OH',
+      score: 85.4,
+    },
+    {
+      date: '1997-08-01',
+      location: 'Allentown, PA',
+      score: 83.9,
+    },
+    {
+      date: '1997-08-04',
+      location: 'Ft. Edwards, NY',
+      score: 85.8,
+    },
+    {
+      date: '1997-08-05',
+      location: 'Endicott, NY',
+      score: 86.6,
+    },
+    {
+      date: '1997-08-09',
+      location: 'Jacksonville, FL',
+      score: 86.7,
+    },
+    {
+      date: '1997-08-10',
+      location: 'Clearwater, FL',
+      score: 88.5,
+    },
+    {
+      date: '1997-08-14',
+      location: 'Orlando, FL',
+      score: 88.6,
+    },
+    {
+      date: '1997-08-15',
+      location: 'Orlando, FL',
+      score: 87.5,
+    },
+    {
+      date: '1997-08-16',
+      location: 'Orlando, FL',
+      score: 85.6,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1998.ts
+++ b/src/lib/data/seasons/1998.ts
@@ -1,0 +1,158 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1998: SeasonScores = {
+  year: '1998',
+  endDate: '1998-08-15',
+  scores: [
+    {
+      date: '1998-06-23',
+      location: 'Columbus, OH',
+      score: 64.9,
+    },
+    {
+      date: '1998-06-25',
+      location: 'Durham, NC',
+      score: 68.1,
+    },
+    {
+      date: '1998-06-26',
+      location: 'Lynchburg, VA',
+      score: 70,
+    },
+    {
+      date: '1998-06-27',
+      location: 'Elkton, MD',
+      score: 68.6,
+    },
+    {
+      date: '1998-06-30',
+      location: 'Willoughby, OH',
+      score: 66.6,
+    },
+    {
+      date: '1998-07-02',
+      location: 'Kingston, NY',
+      score: 72.4,
+    },
+    {
+      date: '1998-07-03',
+      location: 'Bristol, RI',
+      score: 73.3,
+    },
+    {
+      date: '1998-07-04',
+      location: 'Wakefield, MA',
+      score: 73.7,
+    },
+    {
+      date: '1998-07-07',
+      location: 'Washington DC',
+      score: 76.4,
+    },
+    {
+      date: '1998-07-08',
+      location: 'Blountville, TN',
+      score: 78.4,
+    },
+    {
+      date: '1998-07-11',
+      location: 'Rochester, NY',
+      score: 79,
+    },
+    {
+      date: '1998-07-13',
+      location: 'Endicott, NY',
+      score: 79.3,
+    },
+    {
+      date: '1998-07-14',
+      location: 'Hornell, NY',
+      score: 80.3,
+    },
+    {
+      date: '1998-07-15',
+      location: 'Pittsburgh, PA',
+      score: 80.5,
+    },
+    {
+      date: '1998-07-17',
+      location: 'Port Huron, MI',
+      score: 80.8,
+    },
+    {
+      date: '1998-07-19',
+      location: 'Burlington, IA',
+      score: 80.2,
+    },
+    {
+      date: '1998-07-20',
+      location: 'Omaha, NE',
+      score: 80.1,
+    },
+    {
+      date: '1998-07-21',
+      location: 'Sioux City, IA',
+      score: 81,
+    },
+    {
+      date: '1998-07-23',
+      location: 'Stillwater, MN',
+      score: 81.2,
+    },
+    {
+      date: '1998-07-24',
+      location: 'Ankeny, IA',
+      score: 80.8,
+    },
+    {
+      date: '1998-07-25',
+      location: 'Champaign, IL',
+      score: 81.9,
+    },
+    {
+      date: '1998-07-28',
+      location: 'Cincinnati, OH',
+      score: 81.6,
+    },
+    {
+      date: '1998-07-31',
+      location: 'Ypsilanti, MI',
+      score: 84.7,
+    },
+    {
+      date: '1998-08-02',
+      location: 'Massillon, OH',
+      score: 85.6,
+    },
+    {
+      date: '1998-08-04',
+      location: 'Winston-Salem, NC',
+      score: 86.5,
+    },
+    {
+      date: '1998-08-05',
+      location: 'Hampton, VA',
+      score: 85.7,
+    },
+    {
+      date: '1998-08-08',
+      location: 'Allentown, PA',
+      score: 87.2,
+    },
+    {
+      date: '1998-08-13',
+      location: 'Orlando, FL',
+      score: 88.5,
+    },
+    {
+      date: '1998-08-14',
+      location: 'Orlando, FL',
+      score: 88.5,
+    },
+    {
+      date: '1998-08-15',
+      location: 'Orlando, FL',
+      score: 87.1,
+    },
+  ],
+};

--- a/src/lib/data/seasons/1999.ts
+++ b/src/lib/data/seasons/1999.ts
@@ -1,0 +1,143 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_1999: SeasonScores = {
+  year: '1999',
+  endDate: '1999-08-14',
+  scores: [
+    {
+      date: '1999-06-26',
+      location: 'Elkton, MD',
+      score: 61.8,
+    },
+    {
+      date: '1999-06-28',
+      location: 'Kingston, NY',
+      score: 67.6,
+    },
+    {
+      date: '1999-06-29',
+      location: 'Endicott, NY',
+      score: 68.6,
+    },
+    {
+      date: '1999-07-02',
+      location: 'Montreal, QUE',
+      score: 68.4,
+    },
+    {
+      date: '1999-07-03',
+      location: 'Bristol, RI',
+      score: 72.3,
+    },
+    {
+      date: '1999-07-07',
+      location: 'Washington DC',
+      score: 72.1,
+    },
+    {
+      date: '1999-07-08',
+      location: 'Buffalo, NY',
+      score: 72.6,
+    },
+    {
+      date: '1999-07-10',
+      location: 'Hershey, PA',
+      score: 74.7,
+    },
+    {
+      date: '1999-07-12',
+      location: 'Marion, OH',
+      score: 72.5,
+    },
+    {
+      date: '1999-07-13',
+      location: 'Willoughby, OH',
+      score: 74.1,
+    },
+    {
+      date: '1999-07-16',
+      location: 'Cumberland, MD',
+      score: 72.7,
+    },
+    {
+      date: '1999-07-17',
+      location: 'Hampton, VA',
+      score: 74.4,
+    },
+    {
+      date: '1999-07-19',
+      location: 'Columbia, SC',
+      score: 74.6,
+    },
+    {
+      date: '1999-07-20',
+      location: 'Troy, AL',
+      score: 73.8,
+    },
+    {
+      date: '1999-07-21',
+      location: 'Ocean Springs, MS',
+      score: 75.3,
+    },
+    {
+      date: '1999-07-23',
+      location: 'Dallas, TX',
+      score: 77.8,
+    },
+    {
+      date: '1999-07-24',
+      location: 'Houston, TX',
+      score: 78.1,
+    },
+    {
+      date: '1999-07-25',
+      location: 'San Antonio, TX',
+      score: 78.7,
+    },
+    {
+      date: '1999-07-29',
+      location: 'Tupelo, MS',
+      score: 78,
+    },
+    {
+      date: '1999-07-31',
+      location: 'Murfreesboro, TN',
+      score: 80.1,
+    },
+    {
+      date: '1999-08-02',
+      location: 'Huntington, WV',
+      score: 80.9,
+    },
+    {
+      date: '1999-08-03',
+      location: 'Erie, PA',
+      score: 82.5,
+    },
+    {
+      date: '1999-08-04',
+      location: 'Rome, NY',
+      score: 82.5,
+    },
+    {
+      date: '1999-08-06',
+      location: 'Allentown, PA',
+      score: 82,
+    },
+    {
+      date: '1999-08-08',
+      location: 'Massilon, OH',
+      score: 83.8,
+    },
+    {
+      date: '1999-08-12',
+      location: 'Madison, WI',
+      score: 84.5,
+    },
+    {
+      date: '1999-08-13',
+      location: 'Madison, WI',
+      score: 83,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2000.ts
+++ b/src/lib/data/seasons/2000.ts
@@ -1,0 +1,153 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2000: SeasonScores = {
+  year: '2000',
+  endDate: '2000-08-12',
+  scores: [
+    {
+      date: '2000-06-23',
+      location: 'La Porte, IN',
+      score: 65.1,
+    },
+    {
+      date: '2000-06-25',
+      location: 'Wisconsin Rapids, WI',
+      score: 64.3,
+    },
+    {
+      date: '2000-06-27',
+      location: 'Charles City, IA',
+      score: 66.7,
+    },
+    {
+      date: '2000-06-28',
+      location: 'Wausau, WI',
+      score: 69.75,
+    },
+    {
+      date: '2000-06-30',
+      location: 'Streator, IL',
+      score: 71.2,
+    },
+    {
+      date: '2000-07-01',
+      location: 'Muskegon, MI',
+      score: 68.95,
+    },
+    {
+      date: '2000-07-03',
+      location: 'Crown Point, IN',
+      score: 71.25,
+    },
+    {
+      date: '2000-07-07',
+      location: 'DeKalb, IL',
+      score: 73.4,
+    },
+    {
+      date: '2000-07-08',
+      location: 'DeKalb, IL',
+      score: 72.1,
+    },
+    {
+      date: '2000-07-11',
+      location: 'Huntington, WV',
+      score: 71.85,
+    },
+    {
+      date: '2000-07-13',
+      location: 'Winston-Salem, NC',
+      score: 73.7,
+    },
+    {
+      date: '2000-07-14',
+      location: 'Columbia, SC',
+      score: 75.2,
+    },
+    {
+      date: '2000-07-15',
+      location: 'Jacksonville, AL',
+      score: 77.75,
+    },
+    {
+      date: '2000-07-16',
+      location: 'Evansville, IN',
+      score: 77.6,
+    },
+    {
+      date: '2000-07-18',
+      location: 'Lawrence, KS',
+      score: 79.3,
+    },
+    {
+      date: '2000-07-19',
+      location: 'Stillwater, MN',
+      score: 78.65,
+    },
+    {
+      date: '2000-07-20',
+      location: 'Stillwater, MN',
+      score: 78.9,
+    },
+    {
+      date: '2000-07-22',
+      location: 'Indianapolis, IN',
+      score: 80,
+    },
+    {
+      date: '2000-07-23',
+      location: 'Centerville, OH',
+      score: 81.6,
+    },
+    {
+      date: '2000-07-25',
+      location: 'Bowling Green, KY',
+      score: 80.15,
+    },
+    {
+      date: '2000-07-27',
+      location: 'Tupelo, MS',
+      score: 82.3,
+    },
+    {
+      date: '2000-07-28',
+      location: 'Murfreesboro, TN',
+      score: 80.5,
+    },
+    {
+      date: '2000-07-30',
+      location: 'Canton, OH',
+      score: 82.85,
+    },
+    {
+      date: '2000-08-02',
+      location: 'Rome, NY',
+      score: 84,
+    },
+    {
+      date: '2000-08-03',
+      location: 'Lynn, MA',
+      score: 84.85,
+    },
+    {
+      date: '2000-08-05',
+      location: 'Allentown, PA',
+      score: 85.6,
+    },
+    {
+      date: '2000-08-10',
+      location: 'College Park, MD',
+      score: 85.1,
+    },
+    {
+      date: '2000-08-11',
+      location: 'College Park, MD',
+      score: 85.15,
+    },
+    {
+      date: '2000-08-12',
+      location: 'College Park, MD',
+      score: 84.4,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2001.ts
+++ b/src/lib/data/seasons/2001.ts
@@ -1,0 +1,163 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2001: SeasonScores = {
+  year: '2001',
+  endDate: '2001-08-11',
+  scores: [
+    {
+      date: '2001-06-16',
+      location: 'Jackson, MI',
+      score: 60.1,
+    },
+    {
+      date: '2001-06-17',
+      location: 'Akron, OH',
+      score: 63.75,
+    },
+    {
+      date: '2001-06-19',
+      location: 'Columbus, OH',
+      score: 64.85,
+    },
+    {
+      date: '2001-06-23',
+      location: 'Rockford, IL',
+      score: 71.8,
+    },
+    {
+      date: '2001-06-24',
+      location: 'Woodstock, IL',
+      score: 70.9,
+    },
+    {
+      date: '2001-06-26',
+      location: 'Lima, OH',
+      score: 72.6,
+    },
+    {
+      date: '2001-06-27',
+      location: 'Bloomington-Normal, IL',
+      score: 69.5,
+    },
+    {
+      date: '2001-06-29',
+      location: 'Crown Point, IN',
+      score: 71.05,
+    },
+    {
+      date: '2001-07-01',
+      location: 'Marion, OH',
+      score: 73.75,
+    },
+    {
+      date: '2001-07-07',
+      location: 'Hershey, PA',
+      score: 74.35,
+    },
+    {
+      date: '2001-07-10',
+      location: 'Burlington, IA',
+      score: 75,
+    },
+    {
+      date: '2001-07-13',
+      location: 'DeKalb, IL',
+      score: 77.7,
+    },
+    {
+      date: '2001-07-14',
+      location: 'DeKalb, IL',
+      score: 77.4,
+    },
+    {
+      date: '2001-07-16',
+      location: 'Alton, IL',
+      score: 79,
+    },
+    {
+      date: '2001-07-17',
+      location: 'Ankeny, IA',
+      score: 80.55,
+    },
+    {
+      date: '2001-07-18',
+      location: 'Wichita, KS',
+      score: 81.05,
+    },
+    {
+      date: '2001-07-19',
+      location: 'Dallas, TX',
+      score: 82.15,
+    },
+    {
+      date: '2001-07-21',
+      location: 'San Antonio, TX',
+      score: 82.55,
+    },
+    {
+      date: '2001-07-21',
+      location: 'San Antonio, TX',
+      score: 80.3,
+    },
+    {
+      date: '2001-07-25',
+      location: 'Sevierville, TN',
+      score: 84.45,
+    },
+    {
+      date: '2001-07-26',
+      location: 'Cincinnati, OH',
+      score: 84.3,
+    },
+    {
+      date: '2001-07-28',
+      location: 'Indianapolis, IN',
+      score: 85.65,
+    },
+    {
+      date: '2001-07-28',
+      location: 'Indianapolis, IN',
+      score: 85.35,
+    },
+    {
+      date: '2001-07-29',
+      location: 'Centerville, OH',
+      score: 86.65,
+    },
+    {
+      date: '2001-07-30',
+      location: 'Pittsburgh, PA',
+      score: 86.15,
+    },
+    {
+      date: '2001-08-01',
+      location: 'Fort Edward, NY',
+      score: 86.85,
+    },
+    {
+      date: '2001-08-03',
+      location: 'Philadelphia, PA',
+      score: 86.85,
+    },
+    {
+      date: '2001-08-05',
+      location: 'Canton, OH',
+      score: 87.5,
+    },
+    {
+      date: '2001-08-09',
+      location: 'Buffalo, NY',
+      score: 89.7,
+    },
+    {
+      date: '2001-08-10',
+      location: 'Buffalo, NY',
+      score: 90.15,
+    },
+    {
+      date: '2001-08-11',
+      location: 'Buffalo, NY',
+      score: 90.75,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2002.ts
+++ b/src/lib/data/seasons/2002.ts
@@ -1,0 +1,153 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2002: SeasonScores = {
+  year: '2002',
+  endDate: '2002-08-10',
+  scores: [
+    {
+      date: '2002-06-15',
+      location: 'Toledo, OH',
+      score: 63.05,
+    },
+    {
+      date: '2002-06-16',
+      location: 'Orrville, OH',
+      score: 64.7,
+    },
+    {
+      date: '2002-06-20',
+      location: 'Marion, OH',
+      score: 65.5,
+    },
+    {
+      date: '2002-06-21',
+      location: 'Jenison, MI',
+      score: 67.25,
+    },
+    {
+      date: '2002-06-22',
+      location: 'Crown Point, IN',
+      score: 67.75,
+    },
+    {
+      date: '2002-06-25',
+      location: 'Lima, OH',
+      score: 70.2,
+    },
+    {
+      date: '2002-06-27',
+      location: 'Normal, IL',
+      score: 72.45,
+    },
+    {
+      date: '2002-06-29',
+      location: 'Toledo, OH',
+      score: 71.65,
+    },
+    {
+      date: '2002-07-03',
+      location: 'Bristol, RI',
+      score: 75.55,
+    },
+    {
+      date: '2002-07-06',
+      location: 'Hershey, PA',
+      score: 77.4,
+    },
+    {
+      date: '2002-07-12',
+      location: 'DeKalb, IL',
+      score: 80.8,
+    },
+    {
+      date: '2002-07-13',
+      location: 'DeKalb, IL',
+      score: 80.95,
+    },
+    {
+      date: '2002-07-15',
+      location: 'Alton, IL',
+      score: 82.3,
+    },
+    {
+      date: '2002-07-16',
+      location: 'Enid, OK',
+      score: 83.2,
+    },
+    {
+      date: '2002-07-18',
+      location: 'Dallas, TX',
+      score: 82.6,
+    },
+    {
+      date: '2002-07-20',
+      location: 'San Antonio, TX',
+      score: 84.2,
+    },
+    {
+      date: '2002-07-22',
+      location: 'Baton Rouge, LA',
+      score: 85.5,
+    },
+    {
+      date: '2002-07-23',
+      location: 'Pascagoula, MS',
+      score: 85.45,
+    },
+    {
+      date: '2002-07-24',
+      location: 'Kennesaw, GA',
+      score: 86.2,
+    },
+    {
+      date: '2002-07-26',
+      location: 'Murfreesboro, TN',
+      score: 86.05,
+    },
+    {
+      date: '2002-07-27',
+      location: 'Indianapolis, IN',
+      score: 87.85,
+    },
+    {
+      date: '2002-07-29',
+      location: 'Sevierville, TN',
+      score: 88.7,
+    },
+    {
+      date: '2002-07-30',
+      location: 'Charlotte, NC',
+      score: 89.35,
+    },
+    {
+      date: '2002-07-31',
+      location: 'Salem, VA',
+      score: 90.9,
+    },
+    {
+      date: '2002-08-03',
+      location: 'Philadelphia, PA',
+      score: 89.85,
+    },
+    {
+      date: '2002-08-04',
+      location: 'Canton, OH',
+      score: 90,
+    },
+    {
+      date: '2002-08-08',
+      location: 'Madison, WI',
+      score: 92.7,
+    },
+    {
+      date: '2002-08-09',
+      location: 'Madison, WI',
+      score: 92.25,
+    },
+    {
+      date: '2002-08-10',
+      location: 'Madison, WI',
+      score: 91.5,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2003.ts
+++ b/src/lib/data/seasons/2003.ts
@@ -1,0 +1,148 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2003: SeasonScores = {
+  year: '2003',
+  endDate: '2003-08-09',
+  scores: [
+    {
+      date: '2003-06-18',
+      location: 'Harrison, OH',
+      score: 67.75,
+    },
+    {
+      date: '2003-06-20',
+      location: 'Sevierville, TN',
+      score: 67.6,
+    },
+    {
+      date: '2003-06-21',
+      location: 'Louisville, KY',
+      score: 66.35,
+    },
+    {
+      date: '2003-06-23',
+      location: 'Atlanta, GA',
+      score: 70.7,
+    },
+    {
+      date: '2003-06-26',
+      location: 'Chesapeake, VA',
+      score: 71.55,
+    },
+    {
+      date: '2003-06-27',
+      location: 'East Rutherford, NJ',
+      score: 70.9,
+    },
+    {
+      date: '2003-06-30',
+      location: 'New London, CT',
+      score: 74.35,
+    },
+    {
+      date: '2003-07-02',
+      location: 'Ft. Edward, NY',
+      score: 74.4,
+    },
+    {
+      date: '2003-07-03',
+      location: 'Bristol, RI',
+      score: 76.25,
+    },
+    {
+      date: '2003-07-05',
+      location: 'Nashua, NH',
+      score: 78.8,
+    },
+    {
+      date: '2003-07-06',
+      location: 'Hershey, PA',
+      score: 78.7,
+    },
+    {
+      date: '2003-07-08',
+      location: 'Fairfield, OH',
+      score: 78.65,
+    },
+    {
+      date: '2003-07-09',
+      location: 'Murray, KY',
+      score: 78.5,
+    },
+    {
+      date: '2003-07-10',
+      location: 'Alton, IL',
+      score: 78.85,
+    },
+    {
+      date: '2003-07-12',
+      location: 'DeKalb, IL',
+      score: 80.3,
+    },
+    {
+      date: '2003-07-16',
+      location: 'Siloam Springs, AR',
+      score: 80.7,
+    },
+    {
+      date: '2003-07-17',
+      location: 'Leander, TX',
+      score: 82.6,
+    },
+    {
+      date: '2003-07-19',
+      location: 'San Antonio, TX',
+      score: 83.15,
+    },
+    {
+      date: '2003-07-21',
+      location: 'Baton Rouge, LA',
+      score: 85.65,
+    },
+    {
+      date: '2003-07-25',
+      location: 'Murfreesboro, TN',
+      score: 84.15,
+    },
+    {
+      date: '2003-07-26',
+      location: 'Indianapolis, IN',
+      score: 86.55,
+    },
+    {
+      date: '2003-07-29',
+      location: 'Erie, PA',
+      score: 88.2,
+    },
+    {
+      date: '2003-07-30',
+      location: 'Rome, NY',
+      score: 88.05,
+    },
+    {
+      date: '2003-07-31',
+      location: 'Lynn, MA',
+      score: 87.8,
+    },
+    {
+      date: '2003-08-02',
+      location: 'Allentown, PA',
+      score: 88.7,
+    },
+    {
+      date: '2003-08-07',
+      location: 'Orlando, FL',
+      score: 89.7,
+    },
+    {
+      date: '2003-08-08',
+      location: 'Orlando, FL',
+      score: 90.4,
+    },
+    {
+      date: '2003-08-09',
+      location: 'Orlando, FL',
+      score: 90.75,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2004.ts
+++ b/src/lib/data/seasons/2004.ts
@@ -1,0 +1,143 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2004: SeasonScores = {
+  year: '2004',
+  endDate: '2004-08-07',
+  scores: [
+    {
+      date: '2004-06-19',
+      location: 'Toledo, OH',
+      score: 70.1,
+    },
+    {
+      date: '2004-06-20',
+      location: 'DeKalb, IL',
+      score: 72.7,
+    },
+    {
+      date: '2004-06-23',
+      location: 'Pt. Huron, MI',
+      score: 73.35,
+    },
+    {
+      date: '2004-06-25',
+      location: 'Bloomington-Normal, IL',
+      score: 74.25,
+    },
+    {
+      date: '2004-06-26',
+      location: 'Louisville, KY',
+      score: 72.9,
+    },
+    {
+      date: '2004-06-28',
+      location: 'Lima, OH',
+      score: 74.95,
+    },
+    {
+      date: '2004-06-29',
+      location: 'Frankfort, IL',
+      score: 76.3,
+    },
+    {
+      date: '2004-07-05',
+      location: 'Dubuque, IA',
+      score: 77.7,
+    },
+    {
+      date: '2004-07-07',
+      location: 'Broken Arrow, OK',
+      score: 80.8,
+    },
+    {
+      date: '2004-07-08',
+      location: 'Dallas, TX',
+      score: 80.25,
+    },
+    {
+      date: '2004-07-10',
+      location: 'San Antonio, TX',
+      score: 83.05,
+    },
+    {
+      date: '2004-07-12',
+      location: 'Baton Rouge, LA',
+      score: 84.05,
+    },
+    {
+      date: '2004-07-13',
+      location: 'Pascagoula, MS',
+      score: 84.45,
+    },
+    {
+      date: '2004-07-15',
+      location: 'Powder Springs, GA',
+      score: 84.6,
+    },
+    {
+      date: '2004-07-17',
+      location: 'Orlando, FL',
+      score: 86.35,
+    },
+    {
+      date: '2004-07-20',
+      location: 'Chesapeake, VA',
+      score: 85.5,
+    },
+    {
+      date: '2004-07-22',
+      location: 'East Rutherford, NJ',
+      score: 87.3,
+    },
+    {
+      date: '2004-07-23',
+      location: 'Allentown, PA',
+      score: 87.075,
+    },
+    {
+      date: '2004-07-25',
+      location: 'Massillon, OH',
+      score: 87.65,
+    },
+    {
+      date: '2004-07-27',
+      location: 'Columbus, OH',
+      score: 88.6,
+    },
+    {
+      date: '2004-07-28',
+      location: 'Fairfield, OH',
+      score: 88.7,
+    },
+    {
+      date: '2004-07-30',
+      location: 'Murfreesboro, TN',
+      score: 88.825,
+    },
+    {
+      date: '2004-07-31',
+      location: 'Indianapolis, IN',
+      score: 90.6,
+    },
+    {
+      date: '2004-08-01',
+      location: 'Ankeny, IA',
+      score: 90.5,
+    },
+    {
+      date: '2004-08-05',
+      location: 'Denver, CO',
+      score: 90.575,
+    },
+    {
+      date: '2004-08-06',
+      location: 'Denver, CO',
+      score: 91.925,
+    },
+    {
+      date: '2004-08-07',
+      location: 'Denver, CO',
+      score: 92.125,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2005.ts
+++ b/src/lib/data/seasons/2005.ts
@@ -1,0 +1,163 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2005: SeasonScores = {
+  year: '2005',
+  endDate: '2005-08-13',
+  scores: [
+    {
+      date: '2005-06-17',
+      location: 'Elizabeth, PA',
+      score: 67.4,
+    },
+    {
+      date: '2005-06-18',
+      location: 'Toledo, OH',
+      score: 69.25,
+    },
+    {
+      date: '2005-06-19',
+      location: 'Lisle, IL',
+      score: 70.25,
+    },
+    {
+      date: '2005-06-20',
+      location: 'Evansville, IN',
+      score: 73.1,
+    },
+    {
+      date: '2005-06-22',
+      location: 'Fort Mill, SC',
+      score: 72.7,
+    },
+    {
+      date: '2005-06-25',
+      location: 'Orlando, FL',
+      score: 76.325,
+    },
+    {
+      date: '2005-06-27',
+      location: 'Birmingham, AL',
+      score: 76.45,
+    },
+    {
+      date: '2005-06-28',
+      location: 'Memphis, TN',
+      score: 77.7,
+    },
+    {
+      date: '2005-06-30',
+      location: 'Harrison, OH',
+      score: 78,
+    },
+    {
+      date: '2005-07-01',
+      location: 'Bloomington, IL',
+      score: 79.175,
+    },
+    {
+      date: '2005-07-02',
+      location: 'Menasha, WI',
+      score: 80.6,
+    },
+    {
+      date: '2005-07-09',
+      location: 'Columbia, MO',
+      score: 80.875,
+    },
+    {
+      date: '2005-07-12',
+      location: 'Sevierville, TN',
+      score: 83.5,
+    },
+    {
+      date: '2005-07-13',
+      location: 'Dublin, OH',
+      score: 84.1,
+    },
+    {
+      date: '2005-07-15',
+      location: 'Kalamazoo, MI',
+      score: 83,
+    },
+    {
+      date: '2005-07-17',
+      location: 'Winchester, KY',
+      score: 85.75,
+    },
+    {
+      date: '2005-07-18',
+      location: 'Oxford, AL',
+      score: 85.45,
+    },
+    {
+      date: '2005-07-20',
+      location: 'Monroe, LA',
+      score: 86.15,
+    },
+    {
+      date: '2005-07-21',
+      location: 'Dallas, TX',
+      score: 87.4,
+    },
+    {
+      date: '2005-07-23',
+      location: 'San Antonio, TX',
+      score: 82.425,
+    },
+    {
+      date: '2005-07-25',
+      location: 'Enid, OK',
+      score: 87.5,
+    },
+    {
+      date: '2005-07-26',
+      location: 'Broken Arrow, OK',
+      score: 87.45,
+    },
+    {
+      date: '2005-07-29',
+      location: 'Murfreesboro, TN',
+      score: 88.525,
+    },
+    {
+      date: '2005-07-30',
+      location: 'Indianapolis, IN',
+      score: 88.975,
+    },
+    {
+      date: '2005-07-31',
+      location: 'Massillon, OH',
+      score: 90,
+    },
+    {
+      date: '2005-08-01',
+      location: 'Hornell, NY',
+      score: 90.35,
+    },
+    {
+      date: '2005-08-04',
+      location: 'West Chester, PA',
+      score: 91.2,
+    },
+    {
+      date: '2005-08-05',
+      location: 'Allentown, PA',
+      score: 91.4,
+    },
+    {
+      date: '2005-08-11',
+      location: 'Foxboro, MA',
+      score: 92.4,
+    },
+    {
+      date: '2005-08-12',
+      location: 'Foxboro, MA',
+      score: 92.6,
+    },
+    {
+      date: '2005-08-13',
+      location: 'Foxboro, MA',
+      score: 94.45,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2006.ts
+++ b/src/lib/data/seasons/2006.ts
@@ -1,0 +1,163 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2006: SeasonScores = {
+  year: '2006',
+  endDate: '2006-08-12',
+  scores: [
+    {
+      date: '2006-06-17',
+      location: 'Toledo, OH',
+      score: 70.65,
+    },
+    {
+      date: '2006-06-18',
+      location: 'Lisle, IL',
+      score: 72.7,
+    },
+    {
+      date: '2006-06-20',
+      location: 'Ankeny, IA',
+      score: 72.85,
+    },
+    {
+      date: '2006-06-21',
+      location: 'Omaha, NE',
+      score: 74,
+    },
+    {
+      date: '2006-06-22',
+      location: 'Cedar Rapids, IA',
+      score: 75.4,
+    },
+    {
+      date: '2006-06-24',
+      location: 'Columbia, MO',
+      score: 75.3,
+    },
+    {
+      date: '2006-06-25',
+      location: 'Winchester, KY',
+      score: 76.1,
+    },
+    {
+      date: '2006-06-27',
+      location: 'Evansville, IN',
+      score: 78.8,
+    },
+    {
+      date: '2006-06-30',
+      location: 'Bloomington-Normal, IL',
+      score: 80.15,
+    },
+    {
+      date: '2006-07-01',
+      location: 'Michigan City, IN',
+      score: 80.3,
+    },
+    {
+      date: '2006-07-02',
+      location: 'Madison, WI',
+      score: 80.15,
+    },
+    {
+      date: '2006-07-03',
+      location: 'Cedarburg, WI',
+      score: 81.9,
+    },
+    {
+      date: '2006-07-08',
+      location: 'Indianapolis, IN',
+      score: 82.35,
+    },
+    {
+      date: '2006-07-10',
+      location: 'Fairfield, OH',
+      score: 85.35,
+    },
+    {
+      date: '2006-07-12',
+      location: 'Dublin, OH',
+      score: 85.6,
+    },
+    {
+      date: '2006-07-15',
+      location: 'Battle Creek, MI',
+      score: 86.45,
+    },
+    {
+      date: '2006-07-16',
+      location: 'Centerville, OH',
+      score: 87.05,
+    },
+    {
+      date: '2006-07-18',
+      location: 'Tupelo, MS',
+      score: 87.3,
+    },
+    {
+      date: '2006-07-19',
+      location: 'West Monroe, LA',
+      score: 87.3,
+    },
+    {
+      date: '2006-07-22',
+      location: 'San Antonio, TX',
+      score: 89.05,
+    },
+    {
+      date: '2006-07-23',
+      location: 'Denton, TX',
+      score: 89.6,
+    },
+    {
+      date: '2006-07-25',
+      location: 'Wichita Falls, TX',
+      score: 90.95,
+    },
+    {
+      date: '2006-07-26',
+      location: 'Siloam Springs, AR',
+      score: 90.85,
+    },
+    {
+      date: '2006-07-29',
+      location: 'Atlanta, GA',
+      score: 90.725,
+    },
+    {
+      date: '2006-07-30',
+      location: 'Charlotte, NC',
+      score: 91.05,
+    },
+    {
+      date: '2006-07-31',
+      location: 'Massillon, OH',
+      score: 91.45,
+    },
+    {
+      date: '2006-08-02',
+      location: 'Bensalem, PA',
+      score: 92.85,
+    },
+    {
+      date: '2006-08-05',
+      location: 'Allentown, PA',
+      score: 92.35,
+    },
+    {
+      date: '2006-08-10',
+      location: 'Madison, WI',
+      score: 92.975,
+    },
+    {
+      date: '2006-08-11',
+      location: 'Madison, WI',
+      score: 93.5,
+    },
+    {
+      date: '2006-08-12',
+      location: 'Madison, WI',
+      score: 93.175,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2007.ts
+++ b/src/lib/data/seasons/2007.ts
@@ -1,0 +1,153 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2007: SeasonScores = {
+  year: '2007',
+  endDate: '2007-08-11',
+  scores: [
+    {
+      date: '2007-06-16',
+      location: 'Annapolis, MD',
+      score: 71.6,
+    },
+    {
+      date: '2007-06-17',
+      location: 'Pittsburgh, PA',
+      score: 72.7,
+    },
+    {
+      date: '2007-06-19',
+      location: 'Fairfield, OH',
+      score: 74.4,
+    },
+    {
+      date: '2007-06-20',
+      location: 'Decatur, IN',
+      score: 75.45,
+    },
+    {
+      date: '2007-06-23',
+      location: 'Toledo, OH',
+      score: 78.35,
+    },
+    {
+      date: '2007-06-24',
+      location: 'Lisle, IL',
+      score: 78.2,
+    },
+    {
+      date: '2007-06-29',
+      location: 'Normal, IL',
+      score: 80.2,
+    },
+    {
+      date: '2007-06-30',
+      location: 'Kalamazoo, MI',
+      score: 80.9,
+    },
+    {
+      date: '2007-07-01',
+      location: 'Port Huron, MI',
+      score: 81.7,
+    },
+    {
+      date: '2007-07-02',
+      location: 'Centerville, OH',
+      score: 83.7,
+    },
+    {
+      date: '2007-07-06',
+      location: 'Michigan City, IN',
+      score: 82.95,
+    },
+    {
+      date: '2007-07-07',
+      location: 'Canton, OH',
+      score: 83.45,
+    },
+    {
+      date: '2007-07-08',
+      location: 'Allentown, PA',
+      score: 84.75,
+    },
+    {
+      date: '2007-07-10',
+      location: 'Salem, VA',
+      score: 84.85,
+    },
+    {
+      date: '2007-07-13',
+      location: 'Murfreesboro, TN',
+      score: 84.75,
+    },
+    {
+      date: '2007-07-14',
+      location: 'Atlanta, GA',
+      score: 85.925,
+    },
+    {
+      date: '2007-07-16',
+      location: 'Tupelo, MS',
+      score: 86.1,
+    },
+    {
+      date: '2007-07-21',
+      location: 'San Antonio, TX',
+      score: 89.075,
+    },
+    {
+      date: '2007-07-22',
+      location: 'Denton, TX',
+      score: 90.05,
+    },
+    {
+      date: '2007-07-25',
+      location: 'Pittsburg, KS',
+      score: 90.6,
+    },
+    {
+      date: '2007-07-26',
+      location: 'Hutchinson, KS',
+      score: 91.8,
+    },
+    {
+      date: '2007-07-28',
+      location: 'Denver, CO',
+      score: 89.75,
+    },
+    {
+      date: '2007-07-30',
+      location: 'Ogden, UT',
+      score: 90.65,
+    },
+    {
+      date: '2007-07-31',
+      location: 'Boise, ID',
+      score: 92.1,
+    },
+    {
+      date: '2007-08-04',
+      location: 'Stanford, CA',
+      score: 92.075,
+    },
+    {
+      date: '2007-08-05',
+      location: 'Clovis, CA',
+      score: 93.475,
+    },
+    {
+      date: '2007-08-09',
+      location: 'Pasadena, CA',
+      score: 93.7,
+    },
+    {
+      date: '2007-08-10',
+      location: 'Pasadena, CA',
+      score: 93.75,
+    },
+    {
+      date: '2007-08-11',
+      location: 'Pasadena, CA',
+      score: 94.05,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2008.ts
+++ b/src/lib/data/seasons/2008.ts
@@ -1,0 +1,143 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2008: SeasonScores = {
+  year: '2008',
+  endDate: '2008-08-09',
+  scores: [
+    {
+      date: '2008-06-21',
+      location: 'Toledo, OH',
+      score: 68.8,
+    },
+    {
+      date: '2008-06-22',
+      location: 'Dublin, OH',
+      score: 69.5,
+    },
+    {
+      date: '2008-06-23',
+      location: 'Port Huron, MI',
+      score: 71.6,
+    },
+    {
+      date: '2008-06-27',
+      location: 'Normal, IL',
+      score: 74.7,
+    },
+    {
+      date: '2008-06-28',
+      location: 'Madison, WI',
+      score: 75,
+    },
+    {
+      date: '2008-07-01',
+      location: 'Richmond, KY',
+      score: 75.8,
+    },
+    {
+      date: '2008-07-02',
+      location: 'Fairfield, OH',
+      score: 76.5,
+    },
+    {
+      date: '2008-07-05',
+      location: 'Kalamazoo, MI',
+      score: 79.8,
+    },
+    {
+      date: '2008-07-06',
+      location: 'Michigan City, IN',
+      score: 80.6,
+    },
+    {
+      date: '2008-07-07',
+      location: 'Louisville, KY',
+      score: 80.25,
+    },
+    {
+      date: '2008-07-12',
+      location: 'Orlando, FL',
+      score: 82.55,
+    },
+    {
+      date: '2008-07-14',
+      location: 'Ft. Walton Beach, FL',
+      score: 83.85,
+    },
+    {
+      date: '2008-07-15',
+      location: 'Ocean Springs, MS',
+      score: 85,
+    },
+    {
+      date: '2008-07-16',
+      location: 'Lafayette, LA',
+      score: 84.45,
+    },
+    {
+      date: '2008-07-19',
+      location: 'San Antonio, TX',
+      score: 86.65,
+    },
+    {
+      date: '2008-07-20',
+      location: 'Denton, TX',
+      score: 88.05,
+    },
+    {
+      date: '2008-07-23',
+      location: 'Van Buren, AR',
+      score: 89,
+    },
+    {
+      date: '2008-07-25',
+      location: 'Murfreesboro, TN',
+      score: 88.2,
+    },
+    {
+      date: '2008-07-26',
+      location: 'Atlanta, GA',
+      score: 88.1,
+    },
+    {
+      date: '2008-07-29',
+      location: 'Centerville, OH',
+      score: 88.95,
+    },
+    {
+      date: '2008-07-30',
+      location: 'Columbus, OH',
+      score: 89.9,
+    },
+    {
+      date: '2008-08-01',
+      location: 'Allentown, PA',
+      score: 90.8,
+    },
+    {
+      date: '2008-08-03',
+      location: 'Buffalo, NY',
+      score: 92.05,
+    },
+    {
+      date: '2008-08-04',
+      location: 'Massilon, OH',
+      score: 92.35,
+    },
+    {
+      date: '2008-08-07',
+      location: 'Bloomington, IN',
+      score: 92.175,
+    },
+    {
+      date: '2008-08-08',
+      location: 'Bloomington, IN',
+      score: 92.8,
+    },
+    {
+      date: '2008-08-09',
+      location: 'Bloomington, IN',
+      score: 93.175,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2009.ts
+++ b/src/lib/data/seasons/2009.ts
@@ -1,0 +1,148 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2009: SeasonScores = {
+  year: '2009',
+  endDate: '2009-08-08',
+  scores: [
+    {
+      date: '2009-06-23',
+      location: 'Rio Rancho, NM',
+      score: 74.9,
+    },
+    {
+      date: '2009-06-24',
+      location: 'Glendale, AZ',
+      score: 74.6,
+    },
+    {
+      date: '2009-06-26',
+      location: 'Clovis, CA',
+      score: 76,
+    },
+    {
+      date: '2009-06-27',
+      location: 'Stanford, CA',
+      score: 76.2,
+    },
+    {
+      date: '2009-06-28',
+      location: 'Stockton, CA',
+      score: 77.45,
+    },
+    {
+      date: '2009-07-02',
+      location: 'Bakersfield, CA',
+      score: 79.5,
+    },
+    {
+      date: '2009-07-03',
+      location: 'Santa Barbara, CA',
+      score: 80.2,
+    },
+    {
+      date: '2009-07-05',
+      location: 'San Diego, CA',
+      score: 79.7,
+    },
+    {
+      date: '2009-07-08',
+      location: 'Ogden, UT',
+      score: 83.1,
+    },
+    {
+      date: '2009-07-10',
+      location: 'Windsor, CO',
+      score: 82.5,
+    },
+    {
+      date: '2009-07-11',
+      location: 'Denver, CO',
+      score: 84,
+    },
+    {
+      date: '2009-07-13',
+      location: 'Hutchinson, KS',
+      score: 84.95,
+    },
+    {
+      date: '2009-07-16',
+      location: 'Dallas, TX',
+      score: 85.45,
+    },
+    {
+      date: '2009-07-17',
+      location: 'Houston, TX',
+      score: 86.05,
+    },
+    {
+      date: '2009-07-18',
+      location: 'San Antonio, TX',
+      score: 86.5,
+    },
+    {
+      date: '2009-07-19',
+      location: 'Denton, TX',
+      score: 87.05,
+    },
+    {
+      date: '2009-07-21',
+      location: 'Monroe, LA',
+      score: 87.7,
+    },
+    {
+      date: '2009-07-22',
+      location: 'Hattiesburg, MS',
+      score: 88.65,
+    },
+    {
+      date: '2009-07-24',
+      location: 'Murfreesboro, TN',
+      score: 87,
+    },
+    {
+      date: '2009-07-25',
+      location: 'Atlanta, GA',
+      score: 89.8,
+    },
+    {
+      date: '2009-07-27',
+      location: 'Sevierville, TN',
+      score: 89.95,
+    },
+    {
+      date: '2009-07-29',
+      location: 'Centerville, OH',
+      score: 90.95,
+    },
+    {
+      date: '2009-07-31',
+      location: 'Allentown, PA',
+      score: 91.1,
+    },
+    {
+      date: '2009-08-02',
+      location: 'Buffalo, NY',
+      score: 92.55,
+    },
+    {
+      date: '2009-08-03',
+      location: 'Massillon, OH',
+      score: 92.4,
+    },
+    {
+      date: '2009-08-06',
+      location: 'Indianapolis, IN',
+      score: 92.65,
+    },
+    {
+      date: '2009-08-07',
+      location: 'Indianapolis, IN',
+      score: 93.55,
+    },
+    {
+      date: '2009-08-08',
+      location: 'Indianapolis, IN',
+      score: 93.15,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2010.ts
+++ b/src/lib/data/seasons/2010.ts
@@ -1,0 +1,163 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2010: SeasonScores = {
+  year: '2010',
+  endDate: '2010-08-14',
+  scores: [
+    {
+      date: '2010-06-21',
+      location: 'Charleston, WV',
+      score: 73.6,
+    },
+    {
+      date: '2010-06-22',
+      location: 'Louisville, KY',
+      score: 75.6,
+    },
+    {
+      date: '2010-06-24',
+      location: 'Bowling Green, OH',
+      score: 78,
+    },
+    {
+      date: '2010-06-26',
+      location: 'Arlington, VA',
+      score: 78.1,
+    },
+    {
+      date: '2010-06-29',
+      location: 'Ewing, NJ',
+      score: 79.9,
+    },
+    {
+      date: '2010-06-30',
+      location: 'Fort Edward, NY',
+      score: 80.9,
+    },
+    {
+      date: '2010-07-02',
+      location: 'Bristol, RI',
+      score: 82.8,
+    },
+    {
+      date: '2010-07-03',
+      location: 'Lynn, MA',
+      score: 83.2,
+    },
+    {
+      date: '2010-07-07',
+      location: 'Dublin, OH',
+      score: 83.4,
+    },
+    {
+      date: '2010-07-09',
+      location: 'Akron, OH',
+      score: 85.35,
+    },
+    {
+      date: '2010-07-10',
+      location: 'Kalamazoo, MI',
+      score: 86.25,
+    },
+    {
+      date: '2010-07-12',
+      location: 'Fairfield, OH',
+      score: 85.85,
+    },
+    {
+      date: '2010-07-13',
+      location: 'Carmel, IN',
+      score: 87.4,
+    },
+    {
+      date: '2010-07-16',
+      location: 'La Crosse, WI',
+      score: 87.35,
+    },
+    {
+      date: '2010-07-18',
+      location: 'Des Moines, IA',
+      score: 88.25,
+    },
+    {
+      date: '2010-07-19',
+      location: 'Wichita, KS',
+      score: 88.6,
+    },
+    {
+      date: '2010-07-22',
+      location: 'Houston, TX',
+      score: 89.05,
+    },
+    {
+      date: '2010-07-23',
+      location: 'Dallas, TX',
+      score: 89.55,
+    },
+    {
+      date: '2010-07-25',
+      location: 'Converse, TX',
+      score: 89.95,
+    },
+    {
+      date: '2010-07-27',
+      location: 'Ocean Springs, MS',
+      score: 90.9,
+    },
+    {
+      date: '2010-07-29',
+      location: 'Gadsden, AL',
+      score: 91.9,
+    },
+    {
+      date: '2010-07-30',
+      location: 'Murfreesboro, TN',
+      score: 93.55,
+    },
+    {
+      date: '2010-07-31',
+      location: 'Atlanta, GA',
+      score: 93.75,
+    },
+    {
+      date: '2010-08-02',
+      location: 'Centerville, OH',
+      score: 92.8,
+    },
+    {
+      date: '2010-08-03',
+      location: 'Massillon, OH',
+      score: 93.75,
+    },
+    {
+      date: '2010-08-05',
+      location: 'Rome, NY',
+      score: 93.25,
+    },
+    {
+      date: '2010-08-06',
+      location: 'Lawrence, MA',
+      score: 94.6,
+    },
+    {
+      date: '2010-08-07',
+      location: 'Allentown, PA',
+      score: 94.65,
+    },
+    {
+      date: '2010-08-12',
+      location: 'Indianapolis, IN',
+      score: 96.25,
+    },
+    {
+      date: '2010-08-13',
+      location: 'Indianapolis, IN',
+      score: 96.5,
+    },
+    {
+      date: '2010-08-14',
+      location: 'Indianapolis, IN',
+      score: 96.4,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2011.ts
+++ b/src/lib/data/seasons/2011.ts
@@ -1,0 +1,158 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2011: SeasonScores = {
+  year: '2011',
+  endDate: '2011-08-13',
+  scores: [
+    {
+      date: '2011-06-18',
+      location: 'Saginaw, TX',
+      score: 68.9,
+    },
+    {
+      date: '2011-06-19',
+      location: 'Round Rock, TX',
+      score: 70.15,
+    },
+    {
+      date: '2011-06-21',
+      location: 'Martin, TN',
+      score: 70.2,
+    },
+    {
+      date: '2011-06-23',
+      location: 'Pittsburgh, PA',
+      score: 71.7,
+    },
+    {
+      date: '2011-06-25',
+      location: 'Grandville, MI',
+      score: 74,
+    },
+    {
+      date: '2011-06-28',
+      location: 'Woodbury, MN',
+      score: 75.7,
+    },
+    {
+      date: '2011-06-29',
+      location: 'Mankato, MN',
+      score: 76.3,
+    },
+    {
+      date: '2011-07-01',
+      location: 'Oswego, IL',
+      score: 74.9,
+    },
+    {
+      date: '2011-07-02',
+      location: 'Michigan City, IN',
+      score: 76.4,
+    },
+    {
+      date: '2011-07-03',
+      location: 'Cedarburg, WI',
+      score: 78.5,
+    },
+    {
+      date: '2011-07-07',
+      location: 'Akron, OH',
+      score: 80.55,
+    },
+    {
+      date: '2011-07-09',
+      location: 'Madison, WI',
+      score: 79.4,
+    },
+    {
+      date: '2011-07-11',
+      location: 'Davenport, IA',
+      score: 81.15,
+    },
+    {
+      date: '2011-07-16',
+      location: 'Minneapolis, MN',
+      score: 82.9,
+    },
+    {
+      date: '2011-07-17',
+      location: 'Rockford, IL',
+      score: 82.55,
+    },
+    {
+      date: '2011-07-19',
+      location: 'Wichita, KS',
+      score: 83.45,
+    },
+    {
+      date: '2011-07-20',
+      location: 'Broken Arrow, OK',
+      score: 85,
+    },
+    {
+      date: '2011-07-22',
+      location: 'Houston, TX',
+      score: 84.15,
+    },
+    {
+      date: '2011-07-23',
+      location: 'San Antonio, TX',
+      score: 86.6,
+    },
+    {
+      date: '2011-07-25',
+      location: 'Dallas, TX',
+      score: 86.9,
+    },
+    {
+      date: '2011-07-26',
+      location: 'Yukon, OK',
+      score: 86.95,
+    },
+    {
+      date: '2011-07-29',
+      location: 'Murfreesboro, TN',
+      score: 87.2,
+    },
+    {
+      date: '2011-07-30',
+      location: 'Atlanta, GA',
+      score: 88.65,
+    },
+    {
+      date: '2011-08-02',
+      location: 'Charleston, WV',
+      score: 89.1,
+    },
+    {
+      date: '2011-08-04',
+      location: 'Rome, NY',
+      score: 90,
+    },
+    {
+      date: '2011-08-05',
+      location: 'Allentown, PA',
+      score: 90.15,
+    },
+    {
+      date: '2011-08-07',
+      location: 'East Rutherford, NJ',
+      score: 89.25,
+    },
+    {
+      date: '2011-08-11',
+      location: 'Indianapolis, IN',
+      score: 91.8,
+    },
+    {
+      date: '2011-08-12',
+      location: 'Indianapolis, IN',
+      score: 91.6,
+    },
+    {
+      date: '2011-08-13',
+      location: 'Indianapolis, IN',
+      score: 92.05,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2012.ts
+++ b/src/lib/data/seasons/2012.ts
@@ -1,0 +1,148 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2012: SeasonScores = {
+  year: '2012',
+  endDate: '2012-08-11',
+  scores: [
+    {
+      date: '2012-06-16',
+      location: 'Akron, OH',
+      score: 67.8,
+    },
+    {
+      date: '2012-06-17',
+      location: 'Louisville, KY',
+      score: 68.45,
+    },
+    {
+      date: '2012-06-20',
+      location: 'Battle Creek, MI',
+      score: 70.2,
+    },
+    {
+      date: '2012-06-22',
+      location: 'Madison, WI',
+      score: 71.1,
+    },
+    {
+      date: '2012-06-23',
+      location: 'Woodbury, MN',
+      score: 74.1,
+    },
+    {
+      date: '2012-06-26',
+      location: 'Mankato, MN',
+      score: 74.2,
+    },
+    {
+      date: '2012-06-30',
+      location: 'Michigan City, IN',
+      score: 72.7,
+    },
+    {
+      date: '2012-07-01',
+      location: 'Muscatine, IA',
+      score: 75.1,
+    },
+    {
+      date: '2012-07-03',
+      location: 'Cedarburg, WI',
+      score: 76.3,
+    },
+    {
+      date: '2012-07-06',
+      location: 'Whitewater, WI',
+      score: 77.65,
+    },
+    {
+      date: '2012-07-07',
+      location: 'Kalamazoo, MI',
+      score: 78.65,
+    },
+    {
+      date: '2012-07-09',
+      location: 'Centerville, OH',
+      score: 78.85,
+    },
+    {
+      date: '2012-07-11',
+      location: 'Bowling Green, OH',
+      score: 79.95,
+    },
+    {
+      date: '2012-07-13',
+      location: 'La Crosse, WI',
+      score: 81.7,
+    },
+    {
+      date: '2012-07-14',
+      location: 'Minneapolis, MN',
+      score: 81.35,
+    },
+    {
+      date: '2012-07-15',
+      location: 'Rockford, IL',
+      score: 80.95,
+    },
+    {
+      date: '2012-07-19',
+      location: 'Denton, TX',
+      score: 83.1,
+    },
+    {
+      date: '2012-07-20',
+      location: 'Houston, TX',
+      score: 83.2,
+    },
+    {
+      date: '2012-07-21',
+      location: 'San Antonio, TX',
+      score: 84.85,
+    },
+    {
+      date: '2012-07-24',
+      location: 'Dallas, TX',
+      score: 86.1,
+    },
+    {
+      date: '2012-07-27',
+      location: 'Murfreesboro, TN',
+      score: 86.95,
+    },
+    {
+      date: '2012-07-28',
+      location: 'Atlanta, GA',
+      score: 88.2,
+    },
+    {
+      date: '2012-07-29',
+      location: 'Rock Hill, SC',
+      score: 88.15,
+    },
+    {
+      date: '2012-08-03',
+      location: 'Allentown, PA',
+      score: 90.3,
+    },
+    {
+      date: '2012-08-06',
+      location: 'Massillon, OH',
+      score: 91.95,
+    },
+    {
+      date: '2012-08-09',
+      location: 'Indianapolis, IN',
+      score: 92.25,
+    },
+    {
+      date: '2012-08-10',
+      location: 'Indianapolis, IN',
+      score: 92.8,
+    },
+    {
+      date: '2012-08-11',
+      location: 'Indianapolis, IN',
+      score: 92.55,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2013.ts
+++ b/src/lib/data/seasons/2013.ts
@@ -1,0 +1,168 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2013: SeasonScores = {
+  year: '2013',
+  endDate: '2013-08-10',
+  scores: [
+    {
+      date: '2013-06-21',
+      location: 'Mount Sterling, KY',
+      score: 70,
+    },
+    {
+      date: '2013-06-22',
+      location: 'Akron, OH',
+      score: 71.15,
+    },
+    {
+      date: '2013-06-25',
+      location: 'Fairfield, OH',
+      score: 71.4,
+    },
+    {
+      date: '2013-06-26',
+      location: 'Monroeville, PA',
+      score: 73.2,
+    },
+    {
+      date: '2013-06-28',
+      location: 'Jackson, NJ',
+      score: 73.2,
+    },
+    {
+      date: '2013-06-29',
+      location: 'Quincy, MA',
+      score: 73.5,
+    },
+    {
+      date: '2013-06-30',
+      location: 'New Haven, CT',
+      score: 74.3,
+    },
+    {
+      date: '2013-07-03',
+      location: 'Bristol, RI',
+      score: 77.8,
+    },
+    {
+      date: '2013-07-05',
+      location: 'Lynn, MA',
+      score: 78.35,
+    },
+    {
+      date: '2013-07-06',
+      location: 'Chester, PA',
+      score: 78.3,
+    },
+    {
+      date: '2013-07-07',
+      location: 'Chambersburg, PA',
+      score: 78.8,
+    },
+    {
+      date: '2013-07-11',
+      location: 'Warrensburg, MO',
+      score: 78.5,
+    },
+    {
+      date: '2013-07-12',
+      location: 'La Crosse, WI',
+      score: 80.1,
+    },
+    {
+      date: '2013-07-13',
+      location: 'Minneapolis, MN',
+      score: 81.3,
+    },
+    {
+      date: '2013-07-14',
+      location: 'DeKalb, IL',
+      score: 79.75,
+    },
+    {
+      date: '2013-07-19',
+      location: 'Houston, TX',
+      score: 83.35,
+    },
+    {
+      date: '2013-07-20',
+      location: 'San Antonio, TX',
+      score: 85.05,
+    },
+    {
+      date: '2013-07-21',
+      location: 'Round Rock, TX',
+      score: 84.5,
+    },
+    {
+      date: '2013-07-23',
+      location: 'Dallas, TX',
+      score: 85.95,
+    },
+    {
+      date: '2013-07-24',
+      location: 'Little Rock, AR',
+      score: 86.95,
+    },
+    {
+      date: '2013-07-26',
+      location: 'Murfreesboro, TN',
+      score: 87.1,
+    },
+    {
+      date: '2013-07-27',
+      location: 'Charlotte, NC',
+      score: 86.7,
+    },
+    {
+      date: '2013-07-28',
+      location: 'Atlanta, GA',
+      score: 88.2,
+    },
+    {
+      date: '2013-07-30',
+      location: 'Charleston, WV',
+      score: 88.3,
+    },
+    {
+      date: '2013-07-31',
+      location: 'Bealton, VA',
+      score: 90.8,
+    },
+    {
+      date: '2013-08-02',
+      location: 'Allentown, PA',
+      score: 89.05,
+    },
+    {
+      date: '2013-08-04',
+      location: 'Allentown, PA',
+      score: 90.85,
+    },
+    {
+      date: '2013-08-05',
+      location: 'Buffalo, NY',
+      score: 91.5,
+    },
+    {
+      date: '2013-08-06',
+      location: 'Massillon, OH',
+      score: 93.1,
+    },
+    {
+      date: '2013-08-08',
+      location: 'Indianapolis, IN',
+      score: 92.9,
+    },
+    {
+      date: '2013-08-09',
+      location: 'Indianapolis, IN',
+      score: 93.05,
+    },
+    {
+      date: '2013-08-10',
+      location: 'Indianapolis, IN',
+      score: 93.35,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2014.ts
+++ b/src/lib/data/seasons/2014.ts
@@ -1,0 +1,158 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2014: SeasonScores = {
+  year: '2014',
+  endDate: '2014-08-09',
+  scores: [
+    {
+      date: '2014-06-21',
+      location: 'Akron, OH',
+      score: 72.8,
+    },
+    {
+      date: '2014-06-25',
+      location: 'Pittsburgh, PA',
+      score: 75.5,
+    },
+    {
+      date: '2014-06-27',
+      location: 'Chambersburg, PA',
+      score: 77.6,
+    },
+    {
+      date: '2014-06-28',
+      location: 'Jackson, NJ',
+      score: 77.7,
+    },
+    {
+      date: '2014-06-29',
+      location: 'Lawrence, MA',
+      score: 80.2,
+    },
+    {
+      date: '2014-07-03',
+      location: 'Bristol, RI',
+      score: 81.3,
+    },
+    {
+      date: '2014-07-05',
+      location: 'Lynn, MA',
+      score: 83.2,
+    },
+    {
+      date: '2014-07-06',
+      location: 'Chester, PA',
+      score: 84.05,
+    },
+    {
+      date: '2014-07-08',
+      location: 'Fort Wayne, IN',
+      score: 85.15,
+    },
+    {
+      date: '2014-07-11',
+      location: 'Eden Prairie, MN',
+      score: 85.35,
+    },
+    {
+      date: '2014-07-12',
+      location: 'La Crosse, WI',
+      score: 85.85,
+    },
+    {
+      date: '2014-07-13',
+      location: 'DeKalb, IL',
+      score: 84.1,
+    },
+    {
+      date: '2014-07-14',
+      location: 'Warrensburg, MO',
+      score: 85.4,
+    },
+    {
+      date: '2014-07-17',
+      location: 'Denton, TX',
+      score: 87.85,
+    },
+    {
+      date: '2014-07-18',
+      location: 'Houston, TX',
+      score: 89.4,
+    },
+    {
+      date: '2014-07-19',
+      location: 'San Antonio, TX',
+      score: 89.85,
+    },
+    {
+      date: '2014-07-21',
+      location: 'Dallas, TX',
+      score: 91.1,
+    },
+    {
+      date: '2014-07-22',
+      location: 'Mustang, OK',
+      score: 90.75,
+    },
+    {
+      date: '2014-07-23',
+      location: 'Little Rock, AR',
+      score: 90.55,
+    },
+    {
+      date: '2014-07-25',
+      location: 'Nashville, TN',
+      score: 91.5,
+    },
+    {
+      date: '2014-07-26',
+      location: 'Atlanta, GA',
+      score: 92.95,
+    },
+    {
+      date: '2014-07-28',
+      location: 'Charleston, WV',
+      score: 94.25,
+    },
+    {
+      date: '2014-07-30',
+      location: 'West Chester, PA',
+      score: 94.05,
+    },
+    {
+      date: '2014-07-31',
+      location: 'Piscataway, NJ',
+      score: 93.85,
+    },
+    {
+      date: '2014-08-02',
+      location: 'Allentown, PA',
+      score: 94.9,
+    },
+    {
+      date: '2014-08-03',
+      location: 'Buffalo, NY',
+      score: 95.2,
+    },
+    {
+      date: '2014-08-04',
+      location: 'Massillon, OH',
+      score: 95.3,
+    },
+    {
+      date: '2014-08-07',
+      location: 'Indianapolis, IN',
+      score: 95.8,
+    },
+    {
+      date: '2014-08-08',
+      location: 'Indianapolis, IN',
+      score: 96.55,
+    },
+    {
+      date: '2014-08-09',
+      location: 'Indianapolis, IN',
+      score: 97.175,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2015.ts
+++ b/src/lib/data/seasons/2015.ts
@@ -1,0 +1,163 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2015: SeasonScores = {
+  year: '2015',
+  endDate: '2015-08-08',
+  scores: [
+    {
+      date: '2015-06-17',
+      location: 'Indianapolis, IN',
+      score: 68.25,
+    },
+    {
+      date: '2015-06-20',
+      location: 'Akron, OH',
+      score: 73.25,
+    },
+    {
+      date: '2015-06-21',
+      location: 'Lisle, IL',
+      score: 73.7,
+    },
+    {
+      date: '2015-06-22',
+      location: 'Hamilton, OH',
+      score: 73.9,
+    },
+    {
+      date: '2015-06-24',
+      location: 'Pittsburgh, PA',
+      score: 74.9,
+    },
+    {
+      date: '2015-06-27',
+      location: 'Madison, WI',
+      score: 75.7,
+    },
+    {
+      date: '2015-06-28',
+      location: 'Rochester, MN',
+      score: 78,
+    },
+    {
+      date: '2015-06-29',
+      location: 'Mankato, MN',
+      score: 78.9,
+    },
+    {
+      date: '2015-07-03',
+      location: 'Rockford, IL',
+      score: 79.9,
+    },
+    {
+      date: '2015-07-05',
+      location: 'Whitewater, WI',
+      score: 79.45,
+    },
+    {
+      date: '2015-07-07',
+      location: 'Dubuque, IA',
+      score: 80.35,
+    },
+    {
+      date: '2015-07-10',
+      location: 'Casper, WY',
+      score: 83.3,
+    },
+    {
+      date: '2015-07-11',
+      location: 'Denver, CO',
+      score: 83.5,
+    },
+    {
+      date: '2015-07-13',
+      location: 'Warrensburg, MO',
+      score: 83.45,
+    },
+    {
+      date: '2015-07-16',
+      location: 'Denton, TX',
+      score: 85.15,
+    },
+    {
+      date: '2015-07-17',
+      location: 'Houston, TX',
+      score: 85.25,
+    },
+    {
+      date: '2015-07-18',
+      location: 'San Antonio, TX',
+      score: 85.625,
+    },
+    {
+      date: '2015-07-20',
+      location: 'Lafayette, LA',
+      score: 86.5,
+    },
+    {
+      date: '2015-07-21',
+      location: 'Ocean Springs, MS',
+      score: 87.45,
+    },
+    {
+      date: '2015-07-22',
+      location: 'Hattiesburg, MS',
+      score: 87.85,
+    },
+    {
+      date: '2015-07-24',
+      location: 'Murfreesboro, TN',
+      score: 88.15,
+    },
+    {
+      date: '2015-07-25',
+      location: 'Atlanta, GA',
+      score: 89.525,
+    },
+    {
+      date: '2015-07-26',
+      location: 'Winston-Salem, NC',
+      score: 89.95,
+    },
+    {
+      date: '2015-07-27',
+      location: 'Dublin, OH',
+      score: 90.75,
+    },
+    {
+      date: '2015-07-30',
+      location: 'Chester, PA',
+      score: 93.05,
+    },
+    {
+      date: '2015-08-01',
+      location: 'Allentown, PA',
+      score: 93.125,
+    },
+    {
+      date: '2015-08-02',
+      location: 'Buffalo, NY',
+      score: 93.85,
+    },
+    {
+      date: '2015-08-03',
+      location: 'Massillon, OH',
+      score: 94.65,
+    },
+    {
+      date: '2015-08-06',
+      location: 'Indianapolis, IN',
+      score: 95.425,
+    },
+    {
+      date: '2015-08-07',
+      location: 'Indianapolis, IN',
+      score: 95.775,
+    },
+    {
+      date: '2015-08-08',
+      location: 'Indianapolis, IN',
+      score: 96.925,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2016.ts
+++ b/src/lib/data/seasons/2016.ts
@@ -1,0 +1,163 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2016: SeasonScores = {
+  year: '2016',
+  endDate: '2016-08-13',
+  scores: [
+    {
+      date: '2016-06-23',
+      location: 'Indianapolis, IN',
+      score: 69.7,
+    },
+    {
+      date: '2016-06-25',
+      location: 'Massillon, OH',
+      score: 71.5,
+    },
+    {
+      date: '2016-06-27',
+      location: 'Hamilton, OH',
+      score: 72.8,
+    },
+    {
+      date: '2016-06-28',
+      location: 'Pittsburgh, PA',
+      score: 73.1,
+    },
+    {
+      date: '2016-06-30',
+      location: 'Allentown, PA',
+      score: 74.75,
+    },
+    {
+      date: '2016-07-02',
+      location: 'Chestnut Hill, MA',
+      score: 74.8,
+    },
+    {
+      date: '2016-07-03',
+      location: 'Lynn, MA',
+      score: 76.15,
+    },
+    {
+      date: '2016-07-08',
+      location: 'Lexington, SC',
+      score: 78,
+    },
+    {
+      date: '2016-07-09',
+      location: 'Lakeland, FL',
+      score: 79,
+    },
+    {
+      date: '2016-07-11',
+      location: 'Jupiter, FL',
+      score: 81.25,
+    },
+    {
+      date: '2016-07-12',
+      location: 'Daytona Beach, FL',
+      score: 81.95,
+    },
+    {
+      date: '2016-07-15',
+      location: 'Huntsville, AL',
+      score: 82.9,
+    },
+    {
+      date: '2016-07-16',
+      location: 'Alexandria, KY',
+      score: 83.3,
+    },
+    {
+      date: '2016-07-17',
+      location: 'DeKalb, IL',
+      score: 84.1,
+    },
+    {
+      date: '2016-07-18',
+      location: 'Warrensburg, MO',
+      score: 84.65,
+    },
+    {
+      date: '2016-07-21',
+      location: 'Denton, TX',
+      score: 85.25,
+    },
+    {
+      date: '2016-07-22',
+      location: 'Houston, TX',
+      score: 86.15,
+    },
+    {
+      date: '2016-07-23',
+      location: 'San Antonio, TX',
+      score: 87.0625,
+    },
+    {
+      date: '2016-07-25',
+      location: 'Dallas, TX',
+      score: 87.6,
+    },
+    {
+      date: '2016-07-27',
+      location: 'Little Rock, AR',
+      score: 89.6,
+    },
+    {
+      date: '2016-07-29',
+      location: 'Nashville, TN',
+      score: 90.8,
+    },
+    {
+      date: '2016-07-30',
+      location: 'Atlanta, GA',
+      score: 91.7125,
+    },
+    {
+      date: '2016-07-31',
+      location: 'Winston-Salem, NC',
+      score: 91.95,
+    },
+    {
+      date: '2016-08-01',
+      location: 'Charleston, WV',
+      score: 91.75,
+    },
+    {
+      date: '2016-08-04',
+      location: 'Chester, PA',
+      score: 93.45,
+    },
+    {
+      date: '2016-08-05',
+      location: 'Allentown, PA',
+      score: 94.625,
+    },
+    {
+      date: '2016-08-07',
+      location: 'Buffalo, NY',
+      score: 94.5,
+    },
+    {
+      date: '2016-08-08',
+      location: 'Massillon, OH',
+      score: 94.95,
+    },
+    {
+      date: '2016-08-11',
+      location: 'Indianapolis, IN',
+      score: 97.225,
+    },
+    {
+      date: '2016-08-12',
+      location: 'Indianapolis, IN',
+      score: 97.263,
+    },
+    {
+      date: '2016-08-13',
+      location: 'Indianapolis, IN',
+      score: 97.65,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2017.ts
+++ b/src/lib/data/seasons/2017.ts
@@ -1,0 +1,158 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2017: SeasonScores = {
+  year: '2017',
+  endDate: '2017-08-12',
+  scores: [
+    {
+      date: '2017-06-22',
+      location: 'Indianapolis, IN',
+      score: 72.3,
+    },
+    {
+      date: '2017-06-24',
+      location: 'Massillon, OH',
+      score: 72.7,
+    },
+    {
+      date: '2017-06-26',
+      location: 'Hamilton, OH',
+      score: 74.6,
+    },
+    {
+      date: '2017-06-27',
+      location: 'Pittsburgh, PA',
+      score: 74.7,
+    },
+    {
+      date: '2017-07-01',
+      location: 'Lisle, IL',
+      score: 75.4,
+    },
+    {
+      date: '2017-07-02',
+      location: 'La Crosse, WI',
+      score: 76.9,
+    },
+    {
+      date: '2017-07-03',
+      location: 'Mankato, MN',
+      score: 78.3,
+    },
+    {
+      date: '2017-07-07',
+      location: 'Rockford, IL',
+      score: 79.3,
+    },
+    {
+      date: '2017-07-08',
+      location: 'Minneapolis, MN',
+      score: 80.1,
+    },
+    {
+      date: '2017-07-09',
+      location: 'Rochester, MN',
+      score: 81.6,
+    },
+    {
+      date: '2017-07-11',
+      location: 'Johnston, IA',
+      score: 82.15,
+    },
+    {
+      date: '2017-07-15',
+      location: 'Denver, CO',
+      score: 83.85,
+    },
+    {
+      date: '2017-07-17',
+      location: 'El Dorado, KS',
+      score: 85.3,
+    },
+    {
+      date: '2017-07-18',
+      location: 'Broken Arrow, OK',
+      score: 85.15,
+    },
+    {
+      date: '2017-07-20',
+      location: 'Denton, TX',
+      score: 86.35,
+    },
+    {
+      date: '2017-07-21',
+      location: 'Houston, TX',
+      score: 86.45,
+    },
+    {
+      date: '2017-07-22',
+      location: 'San Antonio, TX',
+      score: 88.025,
+    },
+    {
+      date: '2017-07-24',
+      location: 'Dallas, TX',
+      score: 89.25,
+    },
+    {
+      date: '2017-07-26',
+      location: 'Little Rock, AR',
+      score: 90.2,
+    },
+    {
+      date: '2017-07-28',
+      location: 'Nashville, TN',
+      score: 90.475,
+    },
+    {
+      date: '2017-07-29',
+      location: 'Powder Springs, GA',
+      score: 91.175,
+    },
+    {
+      date: '2017-07-30',
+      location: 'Winston-Salem, NC',
+      score: 91.2,
+    },
+    {
+      date: '2017-07-31',
+      location: 'Dublin, OH',
+      score: 92.5,
+    },
+    {
+      date: '2017-08-03',
+      location: 'Chester, PA',
+      score: 92.825,
+    },
+    {
+      date: '2017-08-04',
+      location: 'Allentown, PA',
+      score: 93.4,
+    },
+    {
+      date: '2017-08-06',
+      location: 'Buffalo, NY',
+      score: 93.725,
+    },
+    {
+      date: '2017-08-07',
+      location: 'Massillon, OH',
+      score: 94.025,
+    },
+    {
+      date: '2017-08-10',
+      location: 'Indianapolis, IN',
+      score: 94.6325,
+    },
+    {
+      date: '2017-08-11',
+      location: 'Indianapolis, IN',
+      score: 95.125,
+    },
+    {
+      date: '2017-08-12',
+      location: 'Indianapolis, IN',
+      score: 95.1625,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2018.ts
+++ b/src/lib/data/seasons/2018.ts
@@ -1,0 +1,163 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2018: SeasonScores = {
+  year: '2018',
+  endDate: '2018-08-11',
+  scores: [
+    {
+      date: '2018-06-21',
+      location: 'Detroit, MI',
+      score: 70.3,
+    },
+    {
+      date: '2018-06-23',
+      location: 'Akron, OH',
+      score: 71.6,
+    },
+    {
+      date: '2018-06-25',
+      location: 'Hamilton, OH',
+      score: 74.2,
+    },
+    {
+      date: '2018-06-28',
+      location: 'Moon Township, PA',
+      score: 76.4,
+    },
+    {
+      date: '2018-06-30',
+      location: 'Allentown, PA',
+      score: 78.3,
+    },
+    {
+      date: '2018-07-01',
+      location: 'Lawrence, MA',
+      score: 79.05,
+    },
+    {
+      date: '2018-07-02',
+      location: 'Lynn, MA',
+      score: 80.4,
+    },
+    {
+      date: '2018-07-03',
+      location: 'Cranston, RI',
+      score: 80.9,
+    },
+    {
+      date: '2018-07-05',
+      location: 'Clifton, NJ',
+      score: 81.65,
+    },
+    {
+      date: '2018-07-07',
+      location: 'Lexington, SC',
+      score: 82.7,
+    },
+    {
+      date: '2018-07-08',
+      location: 'Orlando, FL',
+      score: 83.85,
+    },
+    {
+      date: '2018-07-11',
+      location: 'Hoschton, GA',
+      score: 84,
+    },
+    {
+      date: '2018-07-12',
+      location: 'Knoxville, TN',
+      score: 85.3,
+    },
+    {
+      date: '2018-07-14',
+      location: 'Alexandria, KY',
+      score: 85.6,
+    },
+    {
+      date: '2018-07-15',
+      location: 'St. Louis, MO',
+      score: 87.125,
+    },
+    {
+      date: '2018-07-16',
+      location: 'Olathe, KS',
+      score: 87.5,
+    },
+    {
+      date: '2018-07-17',
+      location: 'Broken Arrow, OK',
+      score: 89.05,
+    },
+    {
+      date: '2018-07-20',
+      location: 'Katy, TX',
+      score: 89.725,
+    },
+    {
+      date: '2018-07-21',
+      location: 'San Antonio, TX',
+      score: 90.675,
+    },
+    {
+      date: '2018-07-23',
+      location: 'Mesquite, TX',
+      score: 91.35,
+    },
+    {
+      date: '2018-07-25',
+      location: 'Little Rock, AR',
+      score: 91.725,
+    },
+    {
+      date: '2018-07-27',
+      location: 'Murfreesboro, TN',
+      score: 92.25,
+    },
+    {
+      date: '2018-07-28',
+      location: 'Atlanta, GA',
+      score: 92.775,
+    },
+    {
+      date: '2018-07-29',
+      location: 'Winston-Salem, NC',
+      score: 91.625,
+    },
+    {
+      date: '2018-07-30',
+      location: 'Centerville, OH',
+      score: 92.725,
+    },
+    {
+      date: '2018-08-01',
+      location: 'Chester, PA',
+      score: 93.15,
+    },
+    {
+      date: '2018-08-05',
+      location: 'Buffalo, NY',
+      score: 94.2,
+    },
+    {
+      date: '2018-08-06',
+      location: 'Massillon, OH',
+      score: 94.825,
+    },
+    {
+      date: '2018-08-09',
+      location: 'Indianapolis, IN',
+      score: 95.2125,
+    },
+    {
+      date: '2018-08-10',
+      location: 'Indianapolis, IN',
+      score: 96.5875,
+    },
+    {
+      date: '2018-08-11',
+      location: 'Indianapolis, IN',
+      score: 96.95,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2019.ts
+++ b/src/lib/data/seasons/2019.ts
@@ -1,0 +1,163 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2019: SeasonScores = {
+  year: '2019',
+  endDate: '2019-08-10',
+  scores: [
+    {
+      date: '2019-06-20',
+      location: 'Detroit, MI',
+      score: 71.15,
+    },
+    {
+      date: '2019-06-22',
+      location: 'North Canton, OH',
+      score: 71.85,
+    },
+    {
+      date: '2019-06-25',
+      location: 'Hamilton, OH',
+      score: 75.4,
+    },
+    {
+      date: '2019-06-26',
+      location: 'Pittsburgh, PA',
+      score: 77.2,
+    },
+    {
+      date: '2019-06-28',
+      location: 'Allentown, PA',
+      score: 78.65,
+    },
+    {
+      date: '2019-06-29',
+      location: 'Lawrence, MA',
+      score: 79.9,
+    },
+    {
+      date: '2019-07-01',
+      location: 'Lynn, MA',
+      score: 81.75,
+    },
+    {
+      date: '2019-07-02',
+      location: 'East Rutherford, NJ',
+      score: 81.8,
+    },
+    {
+      date: '2019-07-05',
+      location: 'Lisle, IL',
+      score: 82.6,
+    },
+    {
+      date: '2019-07-06',
+      location: 'Whitewater, WI',
+      score: 83.8,
+    },
+    {
+      date: '2019-07-07',
+      location: 'Menomonie, WI',
+      score: 84.9,
+    },
+    {
+      date: '2019-07-09',
+      location: 'Mankato, MN',
+      score: 85.7,
+    },
+    {
+      date: '2019-07-10',
+      location: 'Ankeny, IA',
+      score: 86.3,
+    },
+    {
+      date: '2019-07-13',
+      location: 'DeKalb, IL',
+      score: 87.5,
+    },
+    {
+      date: '2019-07-14',
+      location: 'Belleville, IL',
+      score: 88.1,
+    },
+    {
+      date: '2019-07-15',
+      location: 'Olathe, KS',
+      score: 88.4,
+    },
+    {
+      date: '2019-07-16',
+      location: 'Broken Arrow, OK',
+      score: 89.375,
+    },
+    {
+      date: '2019-07-19',
+      location: 'Katy, TX',
+      score: 90.725,
+    },
+    {
+      date: '2019-07-20',
+      location: 'San Antonio, TX',
+      score: 91.2125,
+    },
+    {
+      date: '2019-07-22',
+      location: 'Mesquite, TX',
+      score: 91.55,
+    },
+    {
+      date: '2019-07-24',
+      location: 'Little Rock, AR',
+      score: 92.05,
+    },
+    {
+      date: '2019-07-26',
+      location: 'Murfreesboro, TN',
+      score: 93.425,
+    },
+    {
+      date: '2019-07-27',
+      location: 'Atlanta, GA',
+      score: 93.7625,
+    },
+    {
+      date: '2019-07-28',
+      location: 'Winston-Salem, NC',
+      score: 94.075,
+    },
+    {
+      date: '2019-07-29',
+      location: 'Centerville, OH',
+      score: 94.35,
+    },
+    {
+      date: '2019-08-02',
+      location: 'Allentown, PA',
+      score: 95.175,
+    },
+    {
+      date: '2019-08-04',
+      location: 'Buffalo, NY',
+      score: 95.875,
+    },
+    {
+      date: '2019-08-05',
+      location: 'Akron, OH',
+      score: 96.15,
+    },
+    {
+      date: '2019-08-08',
+      location: 'Indianapolis, IN',
+      score: 97.65,
+    },
+    {
+      date: '2019-08-09',
+      location: 'Indianapolis, IN',
+      score: 97.55,
+    },
+    {
+      date: '2019-08-10',
+      location: 'Indianapolis, IN',
+      score: 98.2375,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2022.ts
+++ b/src/lib/data/seasons/2022.ts
@@ -1,0 +1,104 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2022: SeasonScores = {
+  year: '2022',
+  color: '#ec4899', // pink-500
+  endDate: '2022-08-13',
+  scores: [
+    {
+      date: '2022-06-28',
+      location: 'Detroit, MI',
+      score: 71.7,
+    },
+    {
+      date: '2022-07-02',
+      location: 'Kent, OH',
+      score: 73.95,
+    },
+    {
+      date: '2022-07-06',
+      location: 'Mason, OH',
+      score: 76.3,
+    },
+    {
+      date: '2022-07-07',
+      location: 'Evansville, IN',
+      score: 78.6,
+    },
+    {
+      date: '2022-07-09',
+      location: 'DeKalb, IL',
+      score: 80.45,
+    },
+    {
+      date: '2022-07-16',
+      location: 'Whitewater, WI',
+      score: 85,
+    },
+    {
+      date: '2022-07-19',
+      location: 'Broken Arrow, OK',
+      score: 87.175,
+    },
+    {
+      date: '2022-07-21',
+      location: 'Denton, TX',
+      score: 87.75,
+    },
+    {
+      date: '2022-07-22',
+      location: 'Houston, TX',
+      score: 89.65,
+    },
+    {
+      date: '2022-07-23',
+      location: 'San Antonio, TX',
+      score: 89.9,
+    },
+    {
+      date: '2022-07-29',
+      location: 'Murfreesboro, TN',
+      score: 91.725,
+    },
+    {
+      date: '2022-07-30',
+      location: 'Atlanta, GA',
+      score: 92.225,
+    },
+    {
+      date: '2022-07-31',
+      location: 'Winston-Salem, NC',
+      score: 92.725,
+    },
+    {
+      date: '2022-08-02',
+      location: 'Annapolis, MD',
+      score: 93.55,
+    },
+    {
+      date: '2022-08-03',
+      location: 'Glassboro, NJ',
+      score: 93.8,
+    },
+    {
+      date: '2022-08-05',
+      location: 'Allentown, PA',
+      score: 94.375,
+    },
+    {
+      date: '2022-08-11',
+      location: 'Indianapolis, IN',
+      score: 95.7,
+    },
+    {
+      date: '2022-08-12',
+      location: 'Indianapolis, IN',
+      score: 96.975,
+    },
+    {
+      date: '2022-08-13',
+      location: 'Indianapolis, IN',
+      score: 97.325,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2023.ts
+++ b/src/lib/data/seasons/2023.ts
@@ -1,0 +1,94 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2023: SeasonScores = {
+  year: '2023',
+  color: '#34d399', // emerald-400
+  endDate: '2023-08-12',
+  scores: [
+    {
+      date: '2023-07-05',
+      location: 'Mason, OH',
+      score: 79.85,
+    },
+    {
+      date: '2023-07-08',
+      location: 'Lexington, SC',
+      score: 81.25,
+    },
+    {
+      date: '2023-07-09',
+      location: 'Macon, GA',
+      score: 82.7,
+    },
+    {
+      date: '2023-07-11',
+      location: 'Douglasville, GA',
+      score: 84.9,
+    },
+    {
+      date: '2023-07-15',
+      location: 'Little Rock, AR',
+      score: 86.7,
+    },
+    {
+      date: '2023-07-18',
+      location: 'Broken Arrow, OK',
+      score: 88.65,
+    },
+    {
+      date: '2023-07-20',
+      location: 'Denton, TX',
+      score: 89.45,
+    },
+    {
+      date: '2023-07-21',
+      location: 'Houston, TX',
+      score: 89.35,
+    },
+    {
+      date: '2023-07-22',
+      location: 'San Antonio, TX',
+      score: 90.95,
+    },
+    {
+      date: '2023-07-29',
+      location: 'Atlanta, GA',
+      score: 91.975,
+    },
+    {
+      date: '2023-07-30',
+      location: 'Winston-Salem, NC',
+      score: 92.9,
+    },
+    {
+      date: '2023-08-02',
+      location: 'Glassboro, NJ',
+      score: 95.25,
+    },
+    {
+      date: '2023-08-03',
+      location: 'Lawrence, MA',
+      score: 94.7,
+    },
+    {
+      date: '2023-08-04',
+      location: 'Allentown, PA',
+      score: 95.25,
+    },
+    {
+      date: '2023-08-10',
+      location: 'Indianapolis, IN',
+      score: 96.668,
+    },
+    {
+      date: '2023-08-11',
+      location: 'Indianapolis, IN',
+      score: 96.998,
+    },
+    {
+      date: '2023-08-12',
+      location: 'Indianapolis, IN',
+      score: 97.738,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2024.ts
+++ b/src/lib/data/seasons/2024.ts
@@ -1,0 +1,99 @@
+import { type SeasonScores } from '../base';
+
+export const SEASON_2024: SeasonScores = {
+  year: '2024',
+  color: '#dc2626', // red-600
+  endDate: '2024-08-10',
+  scores: [
+    {
+      date: '2024-07-02',
+      location: 'Mason, OH',
+      score: 78.75,
+    },
+    {
+      date: '2024-07-06',
+      location: 'Whitewater, WI',
+      score: 81.9,
+    },
+    {
+      date: '2024-07-07',
+      location: 'La Crosse, WI',
+      score: 83.4,
+    },
+    {
+      date: '2024-07-13',
+      location: 'DeKalb, IL',
+      score: 87.05,
+    },
+    {
+      date: '2024-07-14',
+      location: 'Ankeny, IA',
+      score: 88.35,
+    },
+    {
+      date: '2024-07-16',
+      location: 'Broken Arrow, OK',
+      score: 89.15,
+    },
+    {
+      date: '2024-07-18',
+      location: 'Denton, TX',
+      score: 90.5,
+    },
+    {
+      date: '2024-07-19',
+      location: 'Prarie View, TX',
+      score: 92.1,
+    },
+    {
+      date: '2024-07-20',
+      location: 'San Antonio, TX',
+      score: 93.025,
+    },
+    {
+      date: '2024-07-26',
+      location: 'Murfreesboro, TN',
+      score: 94.45,
+    },
+    {
+      date: '2024-07-27',
+      location: 'Atlanta, GA',
+      score: 94.425,
+    },
+    {
+      date: '2024-07-28',
+      location: 'Winston-Salem, NC',
+      score: 94.7,
+    },
+    {
+      date: '2024-07-30',
+      location: 'Newark, DE',
+      score: 95.225,
+    },
+    {
+      date: '2024-08-02',
+      location: 'Allentown, PA',
+      score: 95.9,
+    },
+    {
+      date: '2024-08-05',
+      location: 'Canton, OH',
+      score: 96,
+    },
+    {
+      date: '2024-08-08',
+      location: 'Indianapolis, IN',
+      score: 97.525,
+    },
+    {
+      date: '2024-08-09',
+      location: 'Indianapolis, IN',
+      score: 97.925,
+    },
+    {
+      date: '2024-08-10',
+      location: 'Indianapolis, IN',
+      score: 98.75,
+    },
+  ],
+};

--- a/src/lib/data/seasons/2025.ts
+++ b/src/lib/data/seasons/2025.ts
@@ -1,0 +1,91 @@
+import { type SeasonScores } from '../base';
+
+const COLOR_OPTIONS = ['#38bdf8', '#ec4899', '#facc15'];
+
+export const SEASON_2025: SeasonScores = {
+  year: '2025',
+  color: COLOR_OPTIONS[Math.floor(Math.random() * COLOR_OPTIONS.length)],
+  endDate: '2025-08-09',
+  scores: [
+    {
+      date: '2025-07-06',
+      location: 'La Crosse, WI',
+      score: 83.3,
+    },
+    {
+      date: '2025-07-12',
+      location: 'Lisle, IL',
+      score: 86.5,
+    },
+    {
+      date: '2025-07-15',
+      location: 'Broken Arrow, OK',
+      score: 88.55,
+    },
+    {
+      date: '2025-07-17',
+      location: 'Denton, TX',
+      score: 90.3,
+    },
+    {
+      date: '2025-07-18',
+      location: 'Houston, TX',
+      score: 91.25,
+    },
+    {
+      date: '2025-07-19',
+      location: 'San Antonio, TX',
+      score: 92.825,
+    },
+    {
+      date: '2025-07-20',
+      location: 'Bedford, TX',
+      score: 92.95,
+    },
+    {
+      date: '2025-07-25',
+      location: 'Nashville, TN',
+      score: 94.4,
+    },
+    {
+      date: '2025-07-26',
+      location: 'Atlanta, GA',
+      score: 95.025,
+    },
+    {
+      date: '2025-07-27',
+      location: 'Winston-Salem, NC',
+      score: 94.55,
+    },
+    {
+      date: '2025-07-30',
+      location: 'Glassboro, NJ',
+      score: 95.85,
+    },
+    {
+      date: '2025-08-01',
+      location: 'Allentown, PA',
+      score: 96.475,
+    },
+    {
+      date: '2025-08-04',
+      location: 'Canton, OH',
+      score: 97.075,
+    },
+    {
+      date: '2025-08-07',
+      location: 'Indianapolis, IN',
+      score: 97.15,
+    },
+    {
+      date: '2025-08-08',
+      location: 'Indianapolis, IN',
+      score: 97.763,
+    },
+    {
+      date: '2025-08-09',
+      location: 'Indianapolis, IN',
+      score: 98.25,
+    },
+  ],
+};

--- a/src/lib/utils/daily-rankings.ts
+++ b/src/lib/utils/daily-rankings.ts
@@ -1,0 +1,75 @@
+import { DateTime } from 'luxon';
+import type { Score, SeasonScores } from '$data/base';
+
+export interface DailyRankingsItem {
+  daysOld: number;
+  location: Score['location'];
+  rank: number;
+  score: Score['score'];
+  year: SeasonScores['year'];
+}
+
+function rankingsItemForSelectedDay(
+  season: SeasonScores,
+  selectedDay: number,
+): Omit<DailyRankingsItem, 'rank'> | undefined {
+  const finalsDateTime = DateTime.fromISO(season.endDate);
+  const scores = season.scores.filter((score) => {
+    const scoreDateTime = DateTime.fromISO(score.date);
+    const daysToFinals = Math.ceil(
+      finalsDateTime.diff(scoreDateTime, 'days').days,
+    );
+    return daysToFinals >= selectedDay;
+  });
+  const latestScore = scores.at(-1);
+  if (latestScore === undefined) return undefined;
+  return {
+    daysOld:
+      Math.ceil(
+        finalsDateTime.diff(DateTime.fromISO(latestScore.date), 'days').days,
+      ) - selectedDay,
+    location: latestScore.location,
+    score: latestScore.score,
+    year: season.year,
+  };
+}
+
+export function buildDailyRankings(
+  seasons: SeasonScores[],
+  selectedDay: number,
+): DailyRankingsItem[] {
+  const sorted = seasons
+    .map((season) => rankingsItemForSelectedDay(season, selectedDay))
+    .filter(
+      (item): item is Omit<DailyRankingsItem, 'rank'> => item !== undefined,
+    )
+    .sort((a, b) => b.score - a.score);
+  return sorted.map((item) => {
+    const firstMatchingScoreIndex = sorted.findIndex(
+      (s) => s.score === item.score,
+    );
+    return { rank: firstMatchingScoreIndex + 1, ...item };
+  });
+}
+
+export function currentDayUntilFinals(seasons: SeasonScores[]): number {
+  const latestSeason = seasons.at(-1);
+  if (!latestSeason) return 0;
+  const latestFinalsDate = DateTime.fromISO(latestSeason.endDate);
+  const now = DateTime.now();
+  if (now > latestFinalsDate) return 0;
+  return Math.ceil(latestFinalsDate.diff(now, 'days').days);
+}
+
+export function maxDayBeforeFinals(seasons: SeasonScores[]): number {
+  const seasonDays = seasons
+    .map((season) => {
+      const firstScore = season.scores[0];
+      if (!firstScore) return undefined;
+      const firstScoreDate = DateTime.fromISO(firstScore.date);
+      const finalsDate = DateTime.fromISO(season.endDate);
+      return finalsDate.diff(firstScoreDate, 'days').days;
+    })
+    .filter((days): days is number => days !== undefined);
+  return Math.max(...seasonDays);
+}

--- a/src/lib/utils/ordinal.ts
+++ b/src/lib/utils/ordinal.ts
@@ -1,0 +1,7 @@
+export function ordinalSuffix(rank: number): string {
+  if (Math.floor(rank / 10) === 1) return 'th';
+  if (rank % 10 === 1) return 'st';
+  if (rank % 10 === 2) return 'nd';
+  if (rank % 10 === 3) return 'rd';
+  return 'th';
+}

--- a/src/lib/utils/url-state.ts
+++ b/src/lib/utils/url-state.ts
@@ -1,0 +1,13 @@
+import { goto } from '$app/navigation';
+import { page } from '$app/state';
+
+export function setParam(key: string, value: string | null) {
+  const url = new URL(page.url);
+  if (value === null || value === '') {
+    url.searchParams.delete(key);
+  } else {
+    url.searchParams.set(key, value);
+  }
+  // eslint-disable-next-line svelte/no-navigation-without-resolve -- same-route nav, only query params change
+  return goto(url, { replaceState: true, keepFocus: true, noScroll: true });
+}

--- a/src/routes/daily-rankings/+page.svelte
+++ b/src/routes/daily-rankings/+page.svelte
@@ -1,13 +1,64 @@
 <script lang="ts">
+  import { browser } from '$app/environment';
+  import { page } from '$app/state';
+  import Card from '$components/shared/Card.svelte';
+  import DaySlider from '$components/daily-rankings/DaySlider.svelte';
+  import Table from '$components/daily-rankings/Table.svelte';
   import PageContent from '$components/shared/PageContent.svelte';
   import PageHeader from '$components/shared/PageHeader.svelte';
+  import { ALL_SEASONS } from '$data';
+  import {
+    buildDailyRankings,
+    currentDayUntilFinals,
+    maxDayBeforeFinals,
+  } from '$lib/utils/daily-rankings';
+  import { setParam } from '$lib/utils/url-state';
+
+  const currentDay = $derived(currentDayUntilFinals(ALL_SEASONS));
+  const dayParam = $derived(browser ? page.url.searchParams.get('day') : null);
+  const selectedDay = $derived.by(() => {
+    const raw = dayParam !== null ? Number(dayParam) : currentDay;
+    return raw >= 0 ? raw : 0;
+  });
+  const maxDay = $derived(maxDayBeforeFinals(ALL_SEASONS));
+  const rankings = $derived(buildDailyRankings(ALL_SEASONS, selectedDay));
+
+  const subtitle = $derived.by(() => {
+    if (selectedDay === 0) return 'Finals Day';
+    return `${selectedDay} ${selectedDay === 1 ? 'day' : 'days'} before DCI Finals`;
+  });
+
+  function onDayChange(day: number) {
+    void setParam('day', day === currentDay ? null : String(day));
+  }
+
+  function resetToToday() {
+    void setParam('day', null);
+  }
 </script>
 
 <svelte:head>
   <title>Daily Rankings | Bluecoats Scores</title>
 </svelte:head>
 
-<PageHeader title="Daily Rankings" />
+<PageHeader title="Daily Rankings" {subtitle}>
+  {#if selectedDay !== currentDay}
+    <button
+      onclick={resetToToday}
+      class="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-xs hover:bg-blue-500 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+      type="button"
+    >
+      Reset to Today
+    </button>
+  {/if}
+</PageHeader>
 <PageContent>
-  <p class="text-gray-500">Coming soon.</p>
+  <div class="grid grid-cols-1 gap-4">
+    <Card>
+      <DaySlider value={selectedDay} maximum={maxDay} onChange={onDayChange} />
+    </Card>
+    <Card disablePadding>
+      <Table {rankings} />
+    </Card>
+  </div>
 </PageContent>

--- a/src/routes/daily-rankings/+page.svelte
+++ b/src/routes/daily-rankings/+page.svelte
@@ -23,10 +23,11 @@
   const maxDay = $derived(maxDayBeforeFinals(ALL_SEASONS));
   const rankings = $derived(buildDailyRankings(ALL_SEASONS, selectedDay));
 
-  const subtitle = $derived.by(() => {
-    if (selectedDay === 0) return 'Finals Day';
-    return `${selectedDay} ${selectedDay === 1 ? 'day' : 'days'} before DCI Finals`;
-  });
+  const subtitle = $derived(
+    selectedDay === 0
+      ? 'Finals Day'
+      : `${selectedDay} ${selectedDay === 1 ? 'day' : 'days'} before DCI Finals`,
+  );
 
   function onDayChange(day: number) {
     void setParam('day', day === currentDay ? null : String(day));

--- a/tests/e2e/daily-rankings.test.ts
+++ b/tests/e2e/daily-rankings.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+
+test('renders rankings table and slider', async ({ page }) => {
+  await page.goto('/daily-rankings');
+  await expect(
+    page.getByRole('heading', { name: 'Daily Rankings' }),
+  ).toBeVisible();
+  await expect(page.getByLabel('Days before Finals')).toBeVisible();
+  // 45 ranked seasons means 45 data rows in the tbody
+  const rows = page.locator('tbody tr');
+  await expect(rows).toHaveCount(45);
+});
+
+test('slider updates URL and "Reset to Today" clears it', async ({ page }) => {
+  await page.goto('/daily-rankings?day=10');
+  await expect(page).toHaveURL(/[?&]day=10\b/);
+  await expect(page.getByText(/10 days before DCI Finals/)).toBeVisible();
+  await page.getByRole('button', { name: 'Reset to Today' }).click();
+  await expect(page).not.toHaveURL(/[?&]day=/);
+});


### PR DESCRIPTION
## Summary
- Ports all 45 season data files (1977–2025) to `src/lib/data/seasons/` and re-exports `ALL_SEASONS` from `src/lib/data/index.ts`.
- Adds `setParam` URL-state helper (`src/lib/utils/url-state.ts`) using `goto` with `replaceState`/`keepFocus`/`noScroll` for query-only navigation.
- Implements `/daily-rankings`: pure ranking logic in `src/lib/utils/daily-rankings.ts`, presentational `DaySlider` + `Table` components, route reads `?day=` and shows "Reset to Today" when off the current day.

## Notable design decisions
- **Prerender + searchParams**: `page.url.searchParams.get('day')` is gated behind `browser` from `$app/environment` — without the gate, prerender errors with "Cannot access url.searchParams on a page with prerendering enabled". Initial render uses `currentDay`; the URL value takes over after hydration.
- **Pure utils**: ranking math lives outside the component for unit-testability later.

## Test plan
- [x] `pnpm lint` — 380 files, 0 errors
- [x] `pnpm test` — 4 Playwright tests pass (smoke + 2 daily-rankings)
- [x] Manual: drag slider → URL updates, refresh restores position, "Reset to Today" clears `day` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)