### PR TITLE
Use $data alias for SeasonScores imports in season files

### DIFF
--- a/src/lib/data/seasons/1977.ts
+++ b/src/lib/data/seasons/1977.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1977: SeasonScores = {
   year: '1977',

--- a/src/lib/data/seasons/1978.ts
+++ b/src/lib/data/seasons/1978.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1978: SeasonScores = {
   year: '1978',

--- a/src/lib/data/seasons/1980.ts
+++ b/src/lib/data/seasons/1980.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1980: SeasonScores = {
   year: '1980',

--- a/src/lib/data/seasons/1981.ts
+++ b/src/lib/data/seasons/1981.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1981: SeasonScores = {
   year: '1981',

--- a/src/lib/data/seasons/1982.ts
+++ b/src/lib/data/seasons/1982.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1982: SeasonScores = {
   year: '1982',

--- a/src/lib/data/seasons/1984.ts
+++ b/src/lib/data/seasons/1984.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1984: SeasonScores = {
   year: '1984',

--- a/src/lib/data/seasons/1985.ts
+++ b/src/lib/data/seasons/1985.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1985: SeasonScores = {
   year: '1985',

--- a/src/lib/data/seasons/1986.ts
+++ b/src/lib/data/seasons/1986.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1986: SeasonScores = {
   year: '1986',

--- a/src/lib/data/seasons/1987.ts
+++ b/src/lib/data/seasons/1987.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1987: SeasonScores = {
   year: '1987',

--- a/src/lib/data/seasons/1988.ts
+++ b/src/lib/data/seasons/1988.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1988: SeasonScores = {
   year: '1988',

--- a/src/lib/data/seasons/1989.ts
+++ b/src/lib/data/seasons/1989.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1989: SeasonScores = {
   year: '1989',

--- a/src/lib/data/seasons/1990.ts
+++ b/src/lib/data/seasons/1990.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1990: SeasonScores = {
   year: '1990',

--- a/src/lib/data/seasons/1991.ts
+++ b/src/lib/data/seasons/1991.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1991: SeasonScores = {
   year: '1991',

--- a/src/lib/data/seasons/1992.ts
+++ b/src/lib/data/seasons/1992.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1992: SeasonScores = {
   year: '1992',

--- a/src/lib/data/seasons/1993.ts
+++ b/src/lib/data/seasons/1993.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1993: SeasonScores = {
   year: '1993',

--- a/src/lib/data/seasons/1994.ts
+++ b/src/lib/data/seasons/1994.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1994: SeasonScores = {
   year: '1994',

--- a/src/lib/data/seasons/1995.ts
+++ b/src/lib/data/seasons/1995.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1995: SeasonScores = {
   year: '1995',

--- a/src/lib/data/seasons/1996.ts
+++ b/src/lib/data/seasons/1996.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1996: SeasonScores = {
   year: '1996',

--- a/src/lib/data/seasons/1997.ts
+++ b/src/lib/data/seasons/1997.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1997: SeasonScores = {
   year: '1997',

--- a/src/lib/data/seasons/1998.ts
+++ b/src/lib/data/seasons/1998.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1998: SeasonScores = {
   year: '1998',

--- a/src/lib/data/seasons/1999.ts
+++ b/src/lib/data/seasons/1999.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_1999: SeasonScores = {
   year: '1999',

--- a/src/lib/data/seasons/2000.ts
+++ b/src/lib/data/seasons/2000.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2000: SeasonScores = {
   year: '2000',

--- a/src/lib/data/seasons/2001.ts
+++ b/src/lib/data/seasons/2001.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2001: SeasonScores = {
   year: '2001',

--- a/src/lib/data/seasons/2002.ts
+++ b/src/lib/data/seasons/2002.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2002: SeasonScores = {
   year: '2002',

--- a/src/lib/data/seasons/2003.ts
+++ b/src/lib/data/seasons/2003.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2003: SeasonScores = {
   year: '2003',

--- a/src/lib/data/seasons/2004.ts
+++ b/src/lib/data/seasons/2004.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2004: SeasonScores = {
   year: '2004',

--- a/src/lib/data/seasons/2005.ts
+++ b/src/lib/data/seasons/2005.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2005: SeasonScores = {
   year: '2005',

--- a/src/lib/data/seasons/2006.ts
+++ b/src/lib/data/seasons/2006.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2006: SeasonScores = {
   year: '2006',

--- a/src/lib/data/seasons/2007.ts
+++ b/src/lib/data/seasons/2007.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2007: SeasonScores = {
   year: '2007',

--- a/src/lib/data/seasons/2008.ts
+++ b/src/lib/data/seasons/2008.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2008: SeasonScores = {
   year: '2008',

--- a/src/lib/data/seasons/2009.ts
+++ b/src/lib/data/seasons/2009.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2009: SeasonScores = {
   year: '2009',

--- a/src/lib/data/seasons/2010.ts
+++ b/src/lib/data/seasons/2010.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2010: SeasonScores = {
   year: '2010',

--- a/src/lib/data/seasons/2011.ts
+++ b/src/lib/data/seasons/2011.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2011: SeasonScores = {
   year: '2011',

--- a/src/lib/data/seasons/2012.ts
+++ b/src/lib/data/seasons/2012.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2012: SeasonScores = {
   year: '2012',

--- a/src/lib/data/seasons/2013.ts
+++ b/src/lib/data/seasons/2013.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2013: SeasonScores = {
   year: '2013',

--- a/src/lib/data/seasons/2014.ts
+++ b/src/lib/data/seasons/2014.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2014: SeasonScores = {
   year: '2014',

--- a/src/lib/data/seasons/2015.ts
+++ b/src/lib/data/seasons/2015.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2015: SeasonScores = {
   year: '2015',

--- a/src/lib/data/seasons/2016.ts
+++ b/src/lib/data/seasons/2016.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2016: SeasonScores = {
   year: '2016',

--- a/src/lib/data/seasons/2017.ts
+++ b/src/lib/data/seasons/2017.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2017: SeasonScores = {
   year: '2017',

--- a/src/lib/data/seasons/2018.ts
+++ b/src/lib/data/seasons/2018.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2018: SeasonScores = {
   year: '2018',

--- a/src/lib/data/seasons/2019.ts
+++ b/src/lib/data/seasons/2019.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2019: SeasonScores = {
   year: '2019',

--- a/src/lib/data/seasons/2022.ts
+++ b/src/lib/data/seasons/2022.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2022: SeasonScores = {
   year: '2022',

--- a/src/lib/data/seasons/2023.ts
+++ b/src/lib/data/seasons/2023.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2023: SeasonScores = {
   year: '2023',

--- a/src/lib/data/seasons/2024.ts
+++ b/src/lib/data/seasons/2024.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 export const SEASON_2024: SeasonScores = {
   year: '2024',

--- a/src/lib/data/seasons/2025.ts
+++ b/src/lib/data/seasons/2025.ts
@@ -1,4 +1,4 @@
-import { type SeasonScores } from '../base';
+import { type SeasonScores } from '$data/base';
 
 const COLOR_OPTIONS = ['#38bdf8', '#ec4899', '#facc15'];
 


### PR DESCRIPTION
## Summary
- Replace `import { type SeasonScores } from '../base'` with `import { type SeasonScores } from '$data/base'` across all 44 season data files
- Pure mechanical refactor; no runtime behavior change

## Test plan
- [x] `pnpm lint:types` passes
- [x] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)