### PR TITLE
Add prettier-plugin-tailwindcss for automatic class sorting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -9,4 +9,3 @@
 !.*
 .*/
 /pnpm-lock.yaml
-*.html

--- a/.prettierrc.mjs
+++ b/.prettierrc.mjs
@@ -1,5 +1,5 @@
 export default {
-  plugins: ['prettier-plugin-svelte'],
+  plugins: ['prettier-plugin-svelte', 'prettier-plugin-tailwindcss'],
   overrides: [
     {
       files: '*.{js,ts,svelte,mjs,mts,cjs,cts}',

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "postcss": "^8.5.12",
     "prettier": "^3.8.3",
     "prettier-plugin-svelte": "^3.4.0",
+    "prettier-plugin-tailwindcss": "^0.8.0",
     "stylelint": "^17.9.1",
     "stylelint-config-standard": "^40.0.0",
     "svelte": "^5.33.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       prettier-plugin-svelte:
         specifier: ^3.4.0
         version: 3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.59.1))
+      prettier-plugin-tailwindcss:
+        specifier: ^0.8.0
+        version: 0.8.0(prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(prettier@3.8.3)
       stylelint:
         specifier: ^17.9.1
         version: 17.9.1(typescript@6.0.3)
@@ -1537,6 +1540,61 @@ packages:
     peerDependencies:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
+
+  prettier-plugin-tailwindcss@0.8.0:
+    resolution: {integrity: sha512-V8ITGH87yuBDF6JpEZTOVlUz/saAwqb8f3HRgUj8Lh+tGCcrmorhsLpYqzygwFwK0PE2Ib6Mv3M7T/uE2tZV1g==}
+    engines: {node: '>=20.19'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-hermes': '*'
+      '@prettier/plugin-oxc': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-hermes':
+        optional: true
+      '@prettier/plugin-oxc':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
 
   prettier@3.8.3:
     resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
@@ -3204,6 +3262,12 @@ snapshots:
     dependencies:
       prettier: 3.8.3
       svelte: 5.55.5(@typescript-eslint/types@8.59.1)
+
+  prettier-plugin-tailwindcss@0.8.0(prettier-plugin-svelte@3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.59.1)))(prettier@3.8.3):
+    dependencies:
+      prettier: 3.8.3
+    optionalDependencies:
+      prettier-plugin-svelte: 3.5.1(prettier@3.8.3)(svelte@5.55.5(@typescript-eslint/types@8.59.1))
 
   prettier@3.8.3: {}
 

--- a/src/lib/components/score-history/SeasonScoresChart.svelte
+++ b/src/lib/components/score-history/SeasonScoresChart.svelte
@@ -18,4 +18,4 @@
   );
 </script>
 
-<div class="grow min-w-200" use:chart={chartOption}></div>
+<div class="min-w-200 grow" use:chart={chartOption}></div>

--- a/src/lib/components/shared/PageContent.svelte
+++ b/src/lib/components/shared/PageContent.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <main>
-  <div class="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8 overflow-auto">
+  <div class="mx-auto max-w-7xl overflow-auto px-4 py-6 sm:px-6 lg:px-8">
     {@render children()}
   </div>
 </main>

--- a/src/lib/components/shared/PageHeader.svelte
+++ b/src/lib/components/shared/PageHeader.svelte
@@ -10,7 +10,7 @@
 
 <header class="bg-white shadow-xs">
   <div
-    class="mx-auto max-w-7xl px-4 py-4 sm:px-6 lg:px-8 flex justify-between items-center"
+    class="mx-auto flex max-w-7xl items-center justify-between px-4 py-4 sm:px-6 lg:px-8"
   >
     <div>
       <h1 class="text-lg/6 font-semibold text-gray-900">{title}</h1>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -50,7 +50,7 @@
       </div>
     </Card>
     <Card>
-      <div class="min-h-svh flex flex-col overflow-x-auto">
+      <div class="flex min-h-svh flex-col overflow-x-auto">
         <SeasonScoresChart
           seasonScores={ALL_SEASONS}
           {selectedYears}


### PR DESCRIPTION
## Summary
- Install `prettier-plugin-tailwindcss` as a devDependency and register it in `.prettierrc.mjs` (after `prettier-plugin-svelte`, per the plugin's recommended ordering).
- Run `pnpm format` to auto-sort existing Tailwind class lists (4 files reformatted).

## Test plan
- [x] `pnpm lint` passes (format, css, types, js)

🤖 Generated with [Claude Code](https://claude.com/claude-code)