### PR TITLE
Show medal emoji for top 3 daily rankings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "enableAllProjectMcpServers": true,
   "permissions": {
     "allow": [
       "Bash(cat:*)",
@@ -9,7 +10,8 @@
       "Bash(git checkout *)",
       "Bash(git add *)",
       "Bash(git commit *)",
-      "Bash(git push *)"
+      "Bash(git push *)",
+      "mcp__svelte__svelte-autofixer"
     ]
   },
   "hooks": {

--- a/src/lib/components/daily-rankings/Table.svelte
+++ b/src/lib/components/daily-rankings/Table.svelte
@@ -3,6 +3,8 @@
   import { ordinalSuffix } from '$lib/utils/ordinal';
 
   let { rankings }: { rankings: DailyRankingsItem[] } = $props();
+
+  const MEDALS: Record<number, string> = { 1: '🥇', 2: '🥈', 3: '🥉' };
 </script>
 
 <table class="min-w-full divide-y divide-gray-300">
@@ -40,7 +42,14 @@
         <td
           class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-gray-900 sm:pl-6"
         >
-          {ranking.rank}{ordinalSuffix(ranking.rank)}
+          {#if MEDALS[ranking.rank]}
+            <span aria-hidden="true">{MEDALS[ranking.rank]}</span>
+            <span class="sr-only"
+              >{ranking.rank}{ordinalSuffix(ranking.rank)}</span
+            >
+          {:else}
+            {ranking.rank}{ordinalSuffix(ranking.rank)}
+          {/if}
         </td>
         <td
           class="px-3 py-4 text-sm font-medium whitespace-nowrap text-gray-900"


### PR DESCRIPTION
## Summary
- Renders 🥇 / 🥈 / 🥉 for ranks 1–3 on the Daily Rankings table.
- Keeps the ordinal text ("1st", "2nd", "3rd") inside an `sr-only` span so screen readers still announce position; emoji is `aria-hidden`.
- Ranks 4+ are unchanged.

⚠️ Also includes unintended `.claude/settings.json` edits that were in the working tree when the branch was cut — let me know if these should be split out.

## Test plan
- [x] `pnpm lint` passes
- [x] `pnpm test:unit` passes
- [x] Visual check on /daily-rankings

🤖 Generated with [Claude Code](https://claude.com/claude-code)