### PR TITLE
Clean up dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,31 +4,37 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 99
+    open-pull-requests-limit: 15
     groups:
-      babel:
-        applies-to: version-updates
-        patterns:
-          - "@babel/*"
-      embroider:
-        applies-to: version-updates
-        patterns:
-          - "@embroider/*"
       eslint:
         applies-to: version-updates
         patterns:
           - "eslint*"
           - "@eslint/*"
+          - "typescript-eslint"
+      svelte:
+        applies-to: version-updates
+        patterns:
+          - "svelte"
+          - "svelte-check"
+          - "@sveltejs/*"
+          - "eslint-plugin-svelte"
+          - "prettier-plugin-svelte"
+      vite:
+        applies-to: version-updates
+        patterns:
+          - "vite"
+          - "vitest"
+          - "@vitest/*"
+      playwright:
+        applies-to: version-updates
+        patterns:
+          - "playwright"
+          - "@playwright/*"
       prettier:
         applies-to: version-updates
         patterns:
-          - "prettier*"
-      qunit:
-        applies-to: version-updates
-        patterns:
-          - "qunit*"
-          - "@types/qunit"
-          - "ember-qunit"
+          - "prettier"
       stylelint:
         applies-to: version-updates
         patterns:
@@ -36,14 +42,15 @@ updates:
       tailwindcss:
         applies-to: version-updates
         patterns:
-          - "@tailwindcss/*"
           - "tailwindcss*"
+          - "@tailwindcss/*"
+          - "prettier-plugin-tailwindcss"
       typescript:
         applies-to: version-updates
         patterns:
           - "@tsconfig/*"
           - "typescript*"
-    reviewers:
+    assignees:
       - kpfefferle
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
@@ -52,5 +59,5 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    reviewers:
+    assignees:
       - kpfefferle


### PR DESCRIPTION
## Summary
- Drop stale Ember-era groups (\`babel\`, \`embroider\`, \`qunit\`) — none of those packages exist in this repo.
- Add \`svelte\`, \`vite\`, and \`playwright\` groups so related ecosystem bumps land in single PRs.
- Move \`prettier-plugin-tailwindcss\` into the \`tailwindcss\` group (its release cadence tracks Tailwind, not Prettier core); tighten the \`prettier\` group to an exact match so other plugin bumps stay separate.
- Pull \`typescript-eslint\` into the \`eslint\` group.
- Lower npm \`open-pull-requests-limit\` from 99 to 15 — grouping makes the higher cap unnecessary.
- Replace deprecated \`reviewers\` with \`assignees\` (GitHub deprecated \`reviewers\` in dependabot.yml in late 2024).

## Test plan
- [ ] Wait for next Dependabot run and confirm groupings look right
- [ ] Confirm \`assignees\` populates correctly on the next opened PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)