### PR TITLE
Add stub for upcoming season with deferred visibility

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -178,7 +178,12 @@ Pure chart-option construction lives in `src/lib/utils/chart-options.ts` (`build
 2. Export `SEASON_[year]` constant with type `SeasonScores`.
 3. Import and add to `ALL_SEASONS_INCLUDING_SCHEDULED` array in `src/lib/data/index.ts`.
 4. Dates should be ISO format (YYYY-MM-DD).
-5. Scores are numeric (decimals allowed). For an upcoming season you can pre-populate `scores` with known schedule entries that have `score: null` — each entry only surfaces in the chart, season select, and daily rankings once it has been assigned a numeric score.
+5. The `score` field is `number | null | undefined`:
+   - **omit** (or `undefined`) — event is on the schedule but has not yet been competed.
+   - **`null`** — event happened but produced no comparable score (e.g. exhibition performances).
+   - **number** — scored competition result (decimals allowed).
+
+   Only numeric-scored entries surface in the chart, season select, and daily rankings; both `null` and `undefined` are filtered out.
 6. `SeasonScores.year` is a **string** (e.g. `"2024"`); do not coerce to number.
 
 The data module exposes two arrays:

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -176,10 +176,15 @@ Pure chart-option construction lives in `src/lib/utils/chart-options.ts` (`build
 
 1. Create `src/lib/data/seasons/[year].ts` following the existing pattern.
 2. Export `SEASON_[year]` constant with type `SeasonScores`.
-3. Import and add to `ALL_SEASONS` array in `src/lib/data/index.ts`.
+3. Import and add to `ALL_SEASONS_INCLUDING_SCHEDULED` array in `src/lib/data/index.ts`.
 4. Dates should be ISO format (YYYY-MM-DD).
-5. Scores are numeric (decimals allowed).
+5. Scores are numeric (decimals allowed). For an upcoming season you can pre-populate `scores` with known schedule entries that have `score: null` — each entry only surfaces in the chart, season select, and daily rankings once it has been assigned a numeric score.
 6. `SeasonScores.year` is a **string** (e.g. `"2024"`); do not coerce to number.
+
+The data module exposes two arrays:
+
+- `POPULATED_SEASONS` — seasons with at least one scored entry. Use this for any UI that displays scores (chart, season select, daily rankings).
+- `ALL_SEASONS_INCLUDING_SCHEDULED` — every known season, including upcoming ones whose `scores` array is empty or contains only schedule entries. Reserved for forward-looking computations like `currentDayUntilFinals`; **do not** use it for UI lists or the chart.
 
 ### Styling
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@sveltejs/kit": "^2.59.0",
     "@sveltejs/vite-plugin-svelte": "^7.0.0",
     "@tailwindcss/vite": "^4.2.4",
+    "@total-typescript/ts-reset": "^0.6.1",
     "@types/luxon": "^3.7.1",
     "concurrently": "^9.2.1",
     "echarts": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.2.4
         version: 4.2.4(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
+      '@total-typescript/ts-reset':
+        specifier: ^0.6.1
+        version: 0.6.1
       '@types/luxon':
         specifier: ^3.7.1
         version: 3.7.1
@@ -466,36 +469,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -601,24 +610,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.4':
     resolution: {integrity: sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.4':
     resolution: {integrity: sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.4':
     resolution: {integrity: sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.4':
     resolution: {integrity: sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==}
@@ -652,6 +665,9 @@ packages:
     resolution: {integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@total-typescript/ts-reset@0.6.1':
+    resolution: {integrity: sha512-cka47fVSo6lfQDIATYqb/vO1nvFfbPw7uWLayIXIhGETj0wcOOlrlkobOMDNQOFr9QOafegUPq13V2+6vtD7yg==}
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -1326,24 +1342,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2411,6 +2431,8 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
       vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.2)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)
+
+  '@total-typescript/ts-reset@0.6.1': {}
 
   '@tybys/wasm-util@0.10.1':
     dependencies:

--- a/src/lib/data/base.ts
+++ b/src/lib/data/base.ts
@@ -1,8 +1,10 @@
 export interface Score {
   date: string;
   location: string;
-  // null means the event is scheduled but has not yet been competed
-  score: number | null;
+  // omitted/undefined: scheduled but not yet competed
+  // null:              competed (e.g. exhibition) with no published score
+  // number:            scored competition result
+  score?: number | null;
 }
 
 export interface SeasonScores {

--- a/src/lib/data/base.ts
+++ b/src/lib/data/base.ts
@@ -1,7 +1,8 @@
 export interface Score {
   date: string;
   location: string;
-  score: number;
+  // null means the event is scheduled but has not yet been competed
+  score: number | null;
 }
 
 export interface SeasonScores {

--- a/src/lib/data/base.ts
+++ b/src/lib/data/base.ts
@@ -1,9 +1,11 @@
 export interface Score {
   date: string;
   location: string;
-  // omitted/undefined: scheduled but not yet competed
-  // null:              competed (e.g. exhibition) with no published score
-  // number:            scored competition result
+  /**
+   * - omitted/`undefined` — scheduled but not yet competed
+   * - `null` — competed (e.g. exhibition) with no published score
+   * - `number` — scored competition result
+   */
   score?: number | null;
 }
 

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -110,5 +110,5 @@ export const ALL_SEASONS_INCLUDING_SCHEDULED: SeasonScores[] = [
  */
 export const POPULATED_SEASONS: SeasonScores[] =
   ALL_SEASONS_INCLUDING_SCHEDULED.filter((season) =>
-    season.scores.some((score) => score.score !== null),
+    season.scores.some((score) => typeof score.score === 'number'),
   );

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -45,6 +45,7 @@ import { SEASON_2022 } from './seasons/2022';
 import { SEASON_2023 } from './seasons/2023';
 import { SEASON_2024 } from './seasons/2024';
 import { SEASON_2025 } from './seasons/2025';
+import { SEASON_2026 } from './seasons/2026';
 
 export const ALL_SEASONS: SeasonScores[] = [
   SEASON_1977,
@@ -92,4 +93,9 @@ export const ALL_SEASONS: SeasonScores[] = [
   SEASON_2023,
   SEASON_2024,
   SEASON_2025,
+  SEASON_2026,
 ];
+
+export const POPULATED_SEASONS: SeasonScores[] = ALL_SEASONS.filter((season) =>
+  season.scores.some((score) => score.score !== null),
+);

--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -47,7 +47,15 @@ import { SEASON_2024 } from './seasons/2024';
 import { SEASON_2025 } from './seasons/2025';
 import { SEASON_2026 } from './seasons/2026';
 
-export const ALL_SEASONS: SeasonScores[] = [
+/**
+ * Every known season, including upcoming ones whose `scores` array is empty
+ * or contains only schedule entries (`score: null`). Reserved for
+ * forward-looking computations like locating the next upcoming finals date.
+ *
+ * For anything that renders scores (charts, dropdowns, rankings) use
+ * {@link POPULATED_SEASONS} instead.
+ */
+export const ALL_SEASONS_INCLUDING_SCHEDULED: SeasonScores[] = [
   SEASON_1977,
   SEASON_1978,
   SEASON_1980,
@@ -96,6 +104,11 @@ export const ALL_SEASONS: SeasonScores[] = [
   SEASON_2026,
 ];
 
-export const POPULATED_SEASONS: SeasonScores[] = ALL_SEASONS.filter((season) =>
-  season.scores.some((score) => score.score !== null),
-);
+/**
+ * Seasons with at least one scored entry. Use this for any UI that displays
+ * scores — chart, season select, daily rankings.
+ */
+export const POPULATED_SEASONS: SeasonScores[] =
+  ALL_SEASONS_INCLUDING_SCHEDULED.filter((season) =>
+    season.scores.some((score) => score.score !== null),
+  );

--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -1,10 +1,7 @@
 import { type SeasonScores } from '$data/base';
 
-const COLOR_OPTIONS = ['#38bdf8', '#ec4899', '#facc15'];
-
 export const SEASON_2026: SeasonScores = {
   year: '2026',
-  color: COLOR_OPTIONS[Math.floor(Math.random() * COLOR_OPTIONS.length)],
   endDate: '2026-08-08',
   scores: [],
 };

--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -1,0 +1,10 @@
+import { type SeasonScores } from '$data/base';
+
+const COLOR_OPTIONS = ['#38bdf8', '#ec4899', '#facc15'];
+
+export const SEASON_2026: SeasonScores = {
+  year: '2026',
+  color: COLOR_OPTIONS[Math.floor(Math.random() * COLOR_OPTIONS.length)],
+  endDate: '2026-08-08',
+  scores: [],
+};

--- a/src/lib/utils/chart-options.ts
+++ b/src/lib/utils/chart-options.ts
@@ -9,9 +9,12 @@ const GRID_OPTION: EChartsOption['grid'] = {
   bottom: '80px',
 };
 
+const X_AXIS_OPTION_MIN = -10 * 7;
+const Y_AXIS_OPTION_MIN = 30;
+
 const X_AXIS_OPTION: EChartsOption['xAxis'] = {
   type: 'value',
-  min: -10 * 7,
+  min: X_AXIS_OPTION_MIN,
   max: 0,
   interval: 7,
   minorTick: { show: true, splitNumber: 7 },
@@ -27,7 +30,7 @@ const X_AXIS_OPTION: EChartsOption['xAxis'] = {
 
 const Y_AXIS_OPTION: EChartsOption['yAxis'] = {
   type: 'value',
-  min: 30,
+  min: Y_AXIS_OPTION_MIN,
   max: 100,
   minorTick: { length: 0, show: true, splitNumber: 2 },
   minorSplitLine: { show: true },
@@ -59,11 +62,16 @@ function seriesForSeason(
   isSelected: boolean,
 ): SeriesOption {
   const finalDate = DateTime.fromISO(season.endDate);
-  const data = season.scores.map(({ date, location, score }) => {
-    const performanceDate = DateTime.fromISO(date);
-    const daysToFinal = finalDate.diff(performanceDate, 'days').days;
-    return [-daysToFinal, score, date, location];
-  });
+  const data = season.scores
+    .filter(
+      (score): score is { date: string; location: string; score: number } =>
+        score.score !== null,
+    )
+    .map(({ date, location, score }) => {
+      const performanceDate = DateTime.fromISO(date);
+      const daysToFinal = finalDate.diff(performanceDate, 'days').days;
+      return [-daysToFinal, score, date, location];
+    });
 
   return {
     ...LINE_SERIES_OPTION_BASE,
@@ -81,20 +89,29 @@ function seriesForSeason(
 }
 
 function xAxisMin(seasons: SeasonScores[]): number {
-  const lengths = seasons.map((season) => {
-    const finalDate = DateTime.fromISO(season.endDate);
-    const firstDate = DateTime.fromISO(season.scores[0].date);
-    return finalDate.diff(firstDate, 'days').days;
-  });
+  const lengths = seasons
+    .map((season) => {
+      const firstScored = season.scores.find((score) => score.score !== null);
+      if (!firstScored) return undefined;
+      const finalDate = DateTime.fromISO(season.endDate);
+      const firstDate = DateTime.fromISO(firstScored.date);
+      return finalDate.diff(firstDate, 'days').days;
+    })
+    .filter((days): days is number => days !== undefined);
+  if (lengths.length === 0) return X_AXIS_OPTION_MIN;
   const longest = Math.max(...lengths);
   const weeks = Math.ceil(longest / 7);
   return -weeks * 7;
 }
 
 function yAxisMin(seasons: SeasonScores[]): number {
-  const minScore = Math.min(
-    ...seasons.flatMap((season) => season.scores.map(({ score }) => score)),
+  const scores = seasons.flatMap((season) =>
+    season.scores
+      .map(({ score }) => score)
+      .filter((score): score is number => score !== null),
   );
+  if (scores.length === 0) return Y_AXIS_OPTION_MIN;
+  const minScore = Math.min(...scores);
   return Math.floor(minScore / 10) * 10;
 }
 

--- a/src/lib/utils/chart-options.ts
+++ b/src/lib/utils/chart-options.ts
@@ -94,7 +94,7 @@ function xAxisMin(seasons: SeasonScores[]): number {
       const firstDate = DateTime.fromISO(firstScored.date);
       return finalDate.diff(firstDate, 'days').days;
     })
-    .filter(Boolean) as number[];
+    .filter(Boolean);
   if (lengths.length === 0) return X_AXIS_OPTION_MIN;
   const longest = Math.max(...lengths);
   const weeks = Math.ceil(longest / 7);
@@ -104,7 +104,7 @@ function xAxisMin(seasons: SeasonScores[]): number {
 function yAxisMin(seasons: SeasonScores[]): number {
   const scores = seasons.flatMap((season) =>
     season.scores.map(({ score }) => score).filter(Boolean),
-  ) as number[];
+  );
   if (scores.length === 0) return Y_AXIS_OPTION_MIN;
   const minScore = Math.min(...scores);
   return Math.floor(minScore / 10) * 10;

--- a/src/lib/utils/chart-options.ts
+++ b/src/lib/utils/chart-options.ts
@@ -63,7 +63,10 @@ function seriesForSeason(
 ): SeriesOption {
   const finalDate = DateTime.fromISO(season.endDate);
   const data = season.scores
-    .filter(({ score }) => Boolean(score))
+    .filter(
+      (entry): entry is { date: string; location: string; score: number } =>
+        entry.score !== null,
+    )
     .map(({ date, location, score }) => {
       const performanceDate = DateTime.fromISO(date);
       const daysToFinal = finalDate.diff(performanceDate, 'days').days;
@@ -88,13 +91,13 @@ function seriesForSeason(
 function xAxisMin(seasons: SeasonScores[]): number {
   const lengths = seasons
     .map((season) => {
-      const firstScored = season.scores.find(({ score }) => Boolean(score));
+      const firstScored = season.scores.find(({ score }) => score !== null);
       if (!firstScored) return undefined;
       const finalDate = DateTime.fromISO(season.endDate);
       const firstDate = DateTime.fromISO(firstScored.date);
       return finalDate.diff(firstDate, 'days').days;
     })
-    .filter(Boolean);
+    .filter((days): days is number => days !== undefined);
   if (lengths.length === 0) return X_AXIS_OPTION_MIN;
   const longest = Math.max(...lengths);
   const weeks = Math.ceil(longest / 7);
@@ -103,7 +106,9 @@ function xAxisMin(seasons: SeasonScores[]): number {
 
 function yAxisMin(seasons: SeasonScores[]): number {
   const scores = seasons.flatMap((season) =>
-    season.scores.map(({ score }) => score).filter(Boolean),
+    season.scores
+      .map(({ score }) => score)
+      .filter((score): score is number => score !== null),
   );
   if (scores.length === 0) return Y_AXIS_OPTION_MIN;
   const minScore = Math.min(...scores);

--- a/src/lib/utils/chart-options.ts
+++ b/src/lib/utils/chart-options.ts
@@ -65,7 +65,7 @@ function seriesForSeason(
   const data = season.scores
     .filter(
       (entry): entry is { date: string; location: string; score: number } =>
-        entry.score !== null,
+        typeof entry.score === 'number',
     )
     .map(({ date, location, score }) => {
       const performanceDate = DateTime.fromISO(date);
@@ -91,7 +91,9 @@ function seriesForSeason(
 function xAxisMin(seasons: SeasonScores[]): number {
   const lengths = seasons
     .map((season) => {
-      const firstScored = season.scores.find(({ score }) => score !== null);
+      const firstScored = season.scores.find(
+        ({ score }) => typeof score === 'number',
+      );
       if (!firstScored) return undefined;
       const finalDate = DateTime.fromISO(season.endDate);
       const firstDate = DateTime.fromISO(firstScored.date);
@@ -108,7 +110,7 @@ function yAxisMin(seasons: SeasonScores[]): number {
   const scores = seasons.flatMap((season) =>
     season.scores
       .map(({ score }) => score)
-      .filter((score): score is number => score !== null),
+      .filter((score): score is number => typeof score === 'number'),
   );
   if (scores.length === 0) return Y_AXIS_OPTION_MIN;
   const minScore = Math.min(...scores);

--- a/src/lib/utils/chart-options.ts
+++ b/src/lib/utils/chart-options.ts
@@ -63,10 +63,7 @@ function seriesForSeason(
 ): SeriesOption {
   const finalDate = DateTime.fromISO(season.endDate);
   const data = season.scores
-    .filter(
-      (score): score is { date: string; location: string; score: number } =>
-        score.score !== null,
-    )
+    .filter(({ score }) => Boolean(score))
     .map(({ date, location, score }) => {
       const performanceDate = DateTime.fromISO(date);
       const daysToFinal = finalDate.diff(performanceDate, 'days').days;
@@ -91,13 +88,13 @@ function seriesForSeason(
 function xAxisMin(seasons: SeasonScores[]): number {
   const lengths = seasons
     .map((season) => {
-      const firstScored = season.scores.find((score) => score.score !== null);
+      const firstScored = season.scores.find(({ score }) => Boolean(score));
       if (!firstScored) return undefined;
       const finalDate = DateTime.fromISO(season.endDate);
       const firstDate = DateTime.fromISO(firstScored.date);
       return finalDate.diff(firstDate, 'days').days;
     })
-    .filter((days): days is number => days !== undefined);
+    .filter(Boolean) as number[];
   if (lengths.length === 0) return X_AXIS_OPTION_MIN;
   const longest = Math.max(...lengths);
   const weeks = Math.ceil(longest / 7);
@@ -106,10 +103,8 @@ function xAxisMin(seasons: SeasonScores[]): number {
 
 function yAxisMin(seasons: SeasonScores[]): number {
   const scores = seasons.flatMap((season) =>
-    season.scores
-      .map(({ score }) => score)
-      .filter((score): score is number => score !== null),
-  );
+    season.scores.map(({ score }) => score).filter(Boolean),
+  ) as number[];
   if (scores.length === 0) return Y_AXIS_OPTION_MIN;
   const minScore = Math.min(...scores);
   return Math.floor(minScore / 10) * 10;

--- a/src/lib/utils/daily-rankings.ts
+++ b/src/lib/utils/daily-rankings.ts
@@ -5,7 +5,7 @@ export interface DailyRankingsItem {
   daysOld: number;
   location: Score['location'];
   rank: number;
-  score: Score['score'];
+  score: number;
   year: SeasonScores['year'];
 }
 
@@ -15,6 +15,7 @@ function rankingsItemForSelectedDay(
 ): Omit<DailyRankingsItem, 'rank'> | undefined {
   const finalsDateTime = DateTime.fromISO(season.endDate);
   const scores = season.scores.filter((score) => {
+    if (score.score === null) return false;
     const scoreDateTime = DateTime.fromISO(score.date);
     const daysToFinals = Math.ceil(
       finalsDateTime.diff(scoreDateTime, 'days').days,
@@ -22,7 +23,7 @@ function rankingsItemForSelectedDay(
     return daysToFinals >= selectedDay;
   });
   const latestScore = scores.at(-1);
-  if (latestScore === undefined) return undefined;
+  if (latestScore === undefined || latestScore.score === null) return undefined;
   return {
     daysOld:
       Math.ceil(
@@ -52,24 +53,30 @@ export function buildDailyRankings(
   });
 }
 
-export function currentDayUntilFinals(seasons: SeasonScores[]): number {
-  const latestSeason = seasons.at(-1);
-  if (!latestSeason) return 0;
-  const latestFinalsDate = DateTime.fromISO(latestSeason.endDate);
+export function currentDayUntilFinals(
+  seasons: SeasonScores[],
+  maxDay: number,
+): number {
   const now = DateTime.now();
-  if (now > latestFinalsDate) return 0;
-  return Math.ceil(latestFinalsDate.diff(now, 'days').days);
+  const upcomingFinals = seasons
+    .map((season) => DateTime.fromISO(season.endDate))
+    .filter((finalsDate) => finalsDate >= now)
+    .sort((a, b) => a.toMillis() - b.toMillis())[0];
+  if (!upcomingFinals) return 0;
+  const days = Math.ceil(upcomingFinals.diff(now, 'days').days);
+  return days > maxDay ? 0 : days;
 }
 
 export function maxDayBeforeFinals(seasons: SeasonScores[]): number {
   const seasonDays = seasons
     .map((season) => {
-      const firstScore = season.scores[0];
-      if (!firstScore) return undefined;
-      const firstScoreDate = DateTime.fromISO(firstScore.date);
+      const firstScored = season.scores.find((score) => score.score !== null);
+      if (!firstScored) return undefined;
+      const firstScoreDate = DateTime.fromISO(firstScored.date);
       const finalsDate = DateTime.fromISO(season.endDate);
       return finalsDate.diff(firstScoreDate, 'days').days;
     })
     .filter((days): days is number => days !== undefined);
+  if (seasonDays.length === 0) return 0;
   return Math.max(...seasonDays);
 }

--- a/src/lib/utils/daily-rankings.ts
+++ b/src/lib/utils/daily-rankings.ts
@@ -70,7 +70,7 @@ export function currentDayUntilFinals(
 export function maxDayBeforeFinals(seasons: SeasonScores[]): number {
   const seasonDays = seasons
     .map((season) => {
-      const firstScored = season.scores.find(({ score }) => Boolean(score));
+      const firstScored = season.scores.find(({ score }) => score !== null);
       if (!firstScored) return undefined;
       const firstScoreDate = DateTime.fromISO(firstScored.date);
       const finalsDate = DateTime.fromISO(season.endDate);

--- a/src/lib/utils/daily-rankings.ts
+++ b/src/lib/utils/daily-rankings.ts
@@ -70,7 +70,7 @@ export function currentDayUntilFinals(
 export function maxDayBeforeFinals(seasons: SeasonScores[]): number {
   const seasonDays = seasons
     .map((season) => {
-      const firstScored = season.scores.find((score) => score.score !== null);
+      const firstScored = season.scores.find(({ score }) => Boolean(score));
       if (!firstScored) return undefined;
       const firstScoreDate = DateTime.fromISO(firstScored.date);
       const finalsDate = DateTime.fromISO(season.endDate);

--- a/src/lib/utils/daily-rankings.ts
+++ b/src/lib/utils/daily-rankings.ts
@@ -15,7 +15,7 @@ function rankingsItemForSelectedDay(
 ): Omit<DailyRankingsItem, 'rank'> | undefined {
   const finalsDateTime = DateTime.fromISO(season.endDate);
   const scores = season.scores.filter((score) => {
-    if (score.score === null) return false;
+    if (typeof score.score !== 'number') return false;
     const scoreDateTime = DateTime.fromISO(score.date);
     const daysToFinals = Math.ceil(
       finalsDateTime.diff(scoreDateTime, 'days').days,
@@ -23,7 +23,9 @@ function rankingsItemForSelectedDay(
     return daysToFinals >= selectedDay;
   });
   const latestScore = scores.at(-1);
-  if (latestScore === undefined || latestScore.score === null) return undefined;
+  if (latestScore === undefined || typeof latestScore.score !== 'number') {
+    return undefined;
+  }
   return {
     daysOld:
       Math.ceil(
@@ -70,7 +72,9 @@ export function currentDayUntilFinals(
 export function maxDayBeforeFinals(seasons: SeasonScores[]): number {
   const seasonDays = seasons
     .map((season) => {
-      const firstScored = season.scores.find(({ score }) => score !== null);
+      const firstScored = season.scores.find(
+        ({ score }) => typeof score === 'number',
+      );
       if (!firstScored) return undefined;
       const firstScoreDate = DateTime.fromISO(firstScored.date);
       const finalsDate = DateTime.fromISO(season.endDate);

--- a/src/reset.d.ts
+++ b/src/reset.d.ts
@@ -1,0 +1,1 @@
+import '@total-typescript/ts-reset';

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,7 +7,7 @@
   import PageHeader from '$components/shared/PageHeader.svelte';
   import SeasonScoresChart from '$components/score-history/SeasonScoresChart.svelte';
   import SeasonSelect from '$components/score-history/SeasonSelect.svelte';
-  import { ALL_SEASONS } from '$data';
+  import { POPULATED_SEASONS } from '$data';
   import { setParam } from '$lib/utils/url-state';
 
   const yearsParam = $derived(
@@ -42,7 +42,7 @@
     <Card>
       <div class="grid grid-cols-1 gap-4">
         <SeasonSelect
-          seasonScores={ALL_SEASONS}
+          seasonScores={POPULATED_SEASONS}
           {selectedYears}
           onChange={onSelectedYearsChange}
         />
@@ -52,7 +52,7 @@
     <Card>
       <div class="flex min-h-svh flex-col overflow-x-auto">
         <SeasonScoresChart
-          seasonScores={ALL_SEASONS}
+          seasonScores={POPULATED_SEASONS}
           {selectedYears}
           {fitAllSeasons}
         />

--- a/src/routes/daily-rankings/+page.svelte
+++ b/src/routes/daily-rankings/+page.svelte
@@ -6,7 +6,7 @@
   import Table from '$components/daily-rankings/Table.svelte';
   import PageContent from '$components/shared/PageContent.svelte';
   import PageHeader from '$components/shared/PageHeader.svelte';
-  import { ALL_SEASONS, POPULATED_SEASONS } from '$data';
+  import { ALL_SEASONS_INCLUDING_SCHEDULED, POPULATED_SEASONS } from '$data';
   import {
     buildDailyRankings,
     currentDayUntilFinals,
@@ -15,7 +15,9 @@
   import { setParam } from '$lib/utils/url-state';
 
   const maxDay = $derived(maxDayBeforeFinals(POPULATED_SEASONS));
-  const currentDay = $derived(currentDayUntilFinals(ALL_SEASONS, maxDay));
+  const currentDay = $derived(
+    currentDayUntilFinals(ALL_SEASONS_INCLUDING_SCHEDULED, maxDay),
+  );
   const dayParam = $derived(browser ? page.url.searchParams.get('day') : null);
   const selectedDay = $derived.by(() => {
     const raw = dayParam !== null ? Number(dayParam) : currentDay;

--- a/src/routes/daily-rankings/+page.svelte
+++ b/src/routes/daily-rankings/+page.svelte
@@ -6,7 +6,7 @@
   import Table from '$components/daily-rankings/Table.svelte';
   import PageContent from '$components/shared/PageContent.svelte';
   import PageHeader from '$components/shared/PageHeader.svelte';
-  import { ALL_SEASONS } from '$data';
+  import { ALL_SEASONS, POPULATED_SEASONS } from '$data';
   import {
     buildDailyRankings,
     currentDayUntilFinals,
@@ -14,14 +14,14 @@
   } from '$lib/utils/daily-rankings';
   import { setParam } from '$lib/utils/url-state';
 
-  const currentDay = $derived(currentDayUntilFinals(ALL_SEASONS));
+  const maxDay = $derived(maxDayBeforeFinals(POPULATED_SEASONS));
+  const currentDay = $derived(currentDayUntilFinals(ALL_SEASONS, maxDay));
   const dayParam = $derived(browser ? page.url.searchParams.get('day') : null);
   const selectedDay = $derived.by(() => {
     const raw = dayParam !== null ? Number(dayParam) : currentDay;
     return raw >= 0 ? raw : 0;
   });
-  const maxDay = $derived(maxDayBeforeFinals(ALL_SEASONS));
-  const rankings = $derived(buildDailyRankings(ALL_SEASONS, selectedDay));
+  const rankings = $derived(buildDailyRankings(POPULATED_SEASONS, selectedDay));
 
   const subtitle = $derived(
     selectedDay === 0

--- a/tests/unit/chart-options.test.ts
+++ b/tests/unit/chart-options.test.ts
@@ -54,4 +54,25 @@ describe('buildChartOption', () => {
     // min score 70 → floor(70/10)*10 = 70
     expect(yAxis.min).toBe(70);
   });
+
+  it('ignores null-scored entries when computing axis bounds and series data', () => {
+    const SEASON_PARTIAL: SeasonScores = {
+      year: '2026',
+      endDate: '2026-08-08',
+      color: '#445566',
+      scores: [
+        { date: '2026-06-20', location: 'TBD', score: null },
+        { date: '2026-07-25', location: 'Atlanta, GA', score: 88.0 },
+      ],
+    };
+    const opt = buildChartOption([SEASON_PARTIAL], ['2026'], false);
+    const xAxis = opt.xAxis as { min: number };
+    const yAxis = opt.yAxis as { min: number };
+    // First scored is 7/25 → 14 days → ceil(14/7)=2 weeks → -14
+    expect(xAxis.min).toBe(-14);
+    // Min score 88 → floor(88/10)*10 = 80
+    expect(yAxis.min).toBe(80);
+    const series = opt.series as Array<{ data: unknown[] }>;
+    expect(series[0].data).toHaveLength(1);
+  });
 });

--- a/tests/unit/chart-options.test.ts
+++ b/tests/unit/chart-options.test.ts
@@ -55,20 +55,22 @@ describe('buildChartOption', () => {
     expect(yAxis.min).toBe(70);
   });
 
-  it('ignores null-scored entries when computing axis bounds and series data', () => {
+  it('ignores scheduled and exhibition entries when computing axis bounds and series data', () => {
     const SEASON_PARTIAL: SeasonScores = {
       year: '2026',
       endDate: '2026-08-08',
       color: '#445566',
       scores: [
+        { date: '2026-07-04', location: 'Hometown, OH', score: null },
         { date: '2026-07-25', location: 'Atlanta, GA', score: 88.0 },
-        { date: '2026-08-08', location: 'Indianapolis, IN', score: null },
+        { date: '2026-08-08', location: 'Indianapolis, IN' },
       ],
     };
     const opt = buildChartOption([SEASON_PARTIAL], ['2026'], false);
     const xAxis = opt.xAxis as { min: number };
     const yAxis = opt.yAxis as { min: number };
     // First scored is 7/25 → 14 days → ceil(14/7)=2 weeks → -14
+    // (the 7/4 exhibition is ignored even though it's earlier)
     expect(xAxis.min).toBe(-14);
     // Min score 88 → floor(88/10)*10 = 80
     expect(yAxis.min).toBe(80);

--- a/tests/unit/chart-options.test.ts
+++ b/tests/unit/chart-options.test.ts
@@ -61,8 +61,8 @@ describe('buildChartOption', () => {
       endDate: '2026-08-08',
       color: '#445566',
       scores: [
-        { date: '2026-06-20', location: 'TBD', score: null },
         { date: '2026-07-25', location: 'Atlanta, GA', score: 88.0 },
+        { date: '2026-08-08', location: 'Indianapolis, IN', score: null },
       ],
     };
     const opt = buildChartOption([SEASON_PARTIAL], ['2026'], false);

--- a/tests/unit/daily-rankings.test.ts
+++ b/tests/unit/daily-rankings.test.ts
@@ -181,16 +181,16 @@ describe('maxDayBeforeFinals', () => {
     expect(maxDayBeforeFinals([empty, SEASON_2025])).toBe(28);
   });
 
-  it('ignores leading entries whose score is null', () => {
+  it('ignores trailing entries whose score is null', () => {
     const partial: SeasonScores = {
       year: '2026',
       endDate: '2026-08-08',
       scores: [
-        { date: '2026-06-20', location: 'TBD', score: null },
         { date: '2026-07-25', location: 'Atlanta, GA', score: 90.0 },
+        { date: '2026-08-08', location: 'Indianapolis, IN', score: null },
       ],
     };
-    // Should measure from 2026-07-25 (14 days), not 2026-06-20 (49 days).
+    // Should measure from 2026-07-25 (14 days).
     expect(maxDayBeforeFinals([partial])).toBe(14);
   });
 
@@ -198,7 +198,9 @@ describe('maxDayBeforeFinals', () => {
     const empty: SeasonScores = {
       year: '2026',
       endDate: '2026-08-08',
-      scores: [{ date: '2026-06-20', location: 'TBD', score: null }],
+      scores: [
+        { date: '2026-08-08', location: 'Indianapolis, IN', score: null },
+      ],
     };
     expect(maxDayBeforeFinals([empty])).toBe(0);
   });

--- a/tests/unit/daily-rankings.test.ts
+++ b/tests/unit/daily-rankings.test.ts
@@ -99,6 +99,21 @@ describe('buildDailyRankings', () => {
     const ranked = buildDailyRankings([SEASON_2024], 0);
     expect(ranked[0].daysOld).toBe(0);
   });
+
+  it('ignores entries whose score is null', () => {
+    const partial: SeasonScores = {
+      year: '2026',
+      endDate: '2026-08-08',
+      scores: [
+        { date: '2026-07-25', location: 'Atlanta, GA', score: 88.0 },
+        { date: '2026-08-08', location: 'Indianapolis, IN', score: null },
+      ],
+    };
+    const ranked = buildDailyRankings([partial], 0);
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0].score).toBe(88.0);
+    expect(ranked[0].location).toBe('Atlanta, GA');
+  });
 });
 
 describe('currentDayUntilFinals', () => {
@@ -110,18 +125,40 @@ describe('currentDayUntilFinals', () => {
   });
 
   it('returns 0 when there are no seasons', () => {
-    expect(currentDayUntilFinals([])).toBe(0);
+    expect(currentDayUntilFinals([], 60)).toBe(0);
   });
 
-  it('returns 0 when the latest finals date has passed', () => {
+  it('returns 0 when every finals date has passed', () => {
     vi.setSystemTime(new Date('2025-09-01T12:00:00Z'));
-    expect(currentDayUntilFinals([SEASON_2025])).toBe(0);
+    expect(currentDayUntilFinals([SEASON_2025], 60)).toBe(0);
   });
 
-  it('returns the days remaining until the latest finals', () => {
+  it('returns the days remaining until the next upcoming finals', () => {
     // 30 days before 2025-08-09 → 2025-07-10
     vi.setSystemTime(new Date('2025-07-10T12:00:00Z'));
-    expect(currentDayUntilFinals([SEASON_2025])).toBe(30);
+    expect(currentDayUntilFinals([SEASON_2025], 60)).toBe(30);
+  });
+
+  it('pivots to the next season once the prior finals has passed', () => {
+    const SEASON_2026: SeasonScores = {
+      year: '2026',
+      endDate: '2026-08-08',
+      scores: [],
+    };
+    // 30 days before 2026-08-08 → 2026-07-09
+    vi.setSystemTime(new Date('2026-07-09T12:00:00Z'));
+    expect(currentDayUntilFinals([SEASON_2025, SEASON_2026], 60)).toBe(30);
+  });
+
+  it('falls back to 0 when the next finals is further away than maxDay', () => {
+    const SEASON_2026: SeasonScores = {
+      year: '2026',
+      endDate: '2026-08-08',
+      scores: [],
+    };
+    // Off-season: 2025 finals just passed, 2026 finals is ~360 days out.
+    vi.setSystemTime(new Date('2025-08-15T12:00:00Z'));
+    expect(currentDayUntilFinals([SEASON_2025, SEASON_2026], 60)).toBe(0);
   });
 });
 
@@ -142,5 +179,27 @@ describe('maxDayBeforeFinals', () => {
       scores: [],
     };
     expect(maxDayBeforeFinals([empty, SEASON_2025])).toBe(28);
+  });
+
+  it('ignores leading entries whose score is null', () => {
+    const partial: SeasonScores = {
+      year: '2026',
+      endDate: '2026-08-08',
+      scores: [
+        { date: '2026-06-20', location: 'TBD', score: null },
+        { date: '2026-07-25', location: 'Atlanta, GA', score: 90.0 },
+      ],
+    };
+    // Should measure from 2026-07-25 (14 days), not 2026-06-20 (49 days).
+    expect(maxDayBeforeFinals([partial])).toBe(14);
+  });
+
+  it('returns 0 when no seasons have any scored entries', () => {
+    const empty: SeasonScores = {
+      year: '2026',
+      endDate: '2026-08-08',
+      scores: [{ date: '2026-06-20', location: 'TBD', score: null }],
+    };
+    expect(maxDayBeforeFinals([empty])).toBe(0);
   });
 });

--- a/tests/unit/daily-rankings.test.ts
+++ b/tests/unit/daily-rankings.test.ts
@@ -160,6 +160,36 @@ describe('currentDayUntilFinals', () => {
     vi.setSystemTime(new Date('2025-08-15T12:00:00Z'));
     expect(currentDayUntilFinals([SEASON_2025, SEASON_2026], 60)).toBe(0);
   });
+
+  it('returns 0 on the exact finals date', () => {
+    // Midnight at the start of finals day — diff is ~0 days, ceil to 0.
+    vi.setSystemTime(new Date('2025-08-09T00:00:00Z'));
+    expect(currentDayUntilFinals([SEASON_2025], 60)).toBe(0);
+  });
+
+  it('picks the earliest upcoming finals when multiple are in the future', () => {
+    const SEASON_2026: SeasonScores = {
+      year: '2026',
+      endDate: '2026-08-08',
+      scores: [],
+    };
+    const SEASON_2027: SeasonScores = {
+      year: '2027',
+      endDate: '2027-08-14',
+      scores: [],
+    };
+    // 30 days before 2026-08-08; 2027 finals is much further out.
+    vi.setSystemTime(new Date('2026-07-09T12:00:00Z'));
+    expect(
+      currentDayUntilFinals([SEASON_2025, SEASON_2026, SEASON_2027], 60),
+    ).toBe(30);
+  });
+
+  it('falls back to 0 when maxDay is 0', () => {
+    // No populated seasons → maxDay is 0; any future finals exceeds the bound.
+    vi.setSystemTime(new Date('2025-07-10T12:00:00Z'));
+    expect(currentDayUntilFinals([SEASON_2025], 0)).toBe(0);
+  });
 });
 
 describe('maxDayBeforeFinals', () => {

--- a/tests/unit/daily-rankings.test.ts
+++ b/tests/unit/daily-rankings.test.ts
@@ -100,16 +100,31 @@ describe('buildDailyRankings', () => {
     expect(ranked[0].daysOld).toBe(0);
   });
 
-  it('ignores entries whose score is null', () => {
+  it('ignores scheduled entries (no score field)', () => {
     const partial: SeasonScores = {
       year: '2026',
       endDate: '2026-08-08',
       scores: [
         { date: '2026-07-25', location: 'Atlanta, GA', score: 88.0 },
-        { date: '2026-08-08', location: 'Indianapolis, IN', score: null },
+        { date: '2026-08-08', location: 'Indianapolis, IN' },
       ],
     };
     const ranked = buildDailyRankings([partial], 0);
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0].score).toBe(88.0);
+    expect(ranked[0].location).toBe('Atlanta, GA');
+  });
+
+  it('ignores exhibition entries (score: null)', () => {
+    const exhibitionSeason: SeasonScores = {
+      year: '2026',
+      endDate: '2026-08-08',
+      scores: [
+        { date: '2026-07-04', location: 'Hometown, OH', score: null },
+        { date: '2026-07-25', location: 'Atlanta, GA', score: 88.0 },
+      ],
+    };
+    const ranked = buildDailyRankings([exhibitionSeason], 0);
     expect(ranked).toHaveLength(1);
     expect(ranked[0].score).toBe(88.0);
     expect(ranked[0].location).toBe('Atlanta, GA');
@@ -211,27 +226,47 @@ describe('maxDayBeforeFinals', () => {
     expect(maxDayBeforeFinals([empty, SEASON_2025])).toBe(28);
   });
 
-  it('ignores trailing entries whose score is null', () => {
+  it('ignores trailing scheduled entries', () => {
     const partial: SeasonScores = {
       year: '2026',
       endDate: '2026-08-08',
       scores: [
         { date: '2026-07-25', location: 'Atlanta, GA', score: 90.0 },
-        { date: '2026-08-08', location: 'Indianapolis, IN', score: null },
+        { date: '2026-08-08', location: 'Indianapolis, IN' },
       ],
     };
     // Should measure from 2026-07-25 (14 days).
     expect(maxDayBeforeFinals([partial])).toBe(14);
   });
 
-  it('returns 0 when no seasons have any scored entries', () => {
-    const empty: SeasonScores = {
+  it('skips leading exhibition entries to find the first scored event', () => {
+    const exhibitionSeason: SeasonScores = {
       year: '2026',
       endDate: '2026-08-08',
       scores: [
-        { date: '2026-08-08', location: 'Indianapolis, IN', score: null },
+        { date: '2026-06-15', location: 'Hometown, OH', score: null },
+        { date: '2026-07-25', location: 'Atlanta, GA', score: 90.0 },
       ],
     };
+    // Should measure from 2026-07-25 (14 days), not the 6/15 exhibition.
+    expect(maxDayBeforeFinals([exhibitionSeason])).toBe(14);
+  });
+
+  it('returns 0 when a season has only scheduled entries', () => {
+    const empty: SeasonScores = {
+      year: '2026',
+      endDate: '2026-08-08',
+      scores: [{ date: '2026-08-08', location: 'Indianapolis, IN' }],
+    };
     expect(maxDayBeforeFinals([empty])).toBe(0);
+  });
+
+  it('returns 0 when a season has only exhibition entries', () => {
+    const exhibitionsOnly: SeasonScores = {
+      year: '2026',
+      endDate: '2026-08-08',
+      scores: [{ date: '2026-07-04', location: 'Hometown, OH', score: null }],
+    };
+    expect(maxDayBeforeFinals([exhibitionsOnly])).toBe(0);
   });
 });


### PR DESCRIPTION
Allow `Score.score` to be null so an upcoming season can be added with
its known schedule populated, but each event only surfaces in the chart,
season select, and daily rankings once it has been assigned a score.

The Daily Rankings page now defaults the day slider by counting down to
the soonest future finals across all seasons (not just the latest one
present in the data), so the next season takes over the default view as
soon as the prior finals passes — but only when within the slider's
populated max range, otherwise it falls back to Finals Day.

Adds an empty 2026 season; schedule entries to follow.

https://claude.ai/code/session_01QacvAgVZJm74GpBCEDehR9