### PR TITLE
Add @types/node to silence svelte-check warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tailwindcss/vite": "^4.2.4",
     "@total-typescript/ts-reset": "^0.6.1",
     "@types/luxon": "^3.7.1",
+    "@types/node": "^25.6.0",
     "concurrently": "^9.2.1",
     "echarts": "^6.0.0",
     "eslint": "^10.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@types/luxon':
         specifier: ^3.7.1
         version: 3.7.1
+      '@types/node':
+        specifier: ^25.6.0
+        version: 25.6.0
       concurrently:
         specifier: ^9.2.1
         version: 9.2.1
@@ -2459,7 +2462,6 @@ snapshots:
   '@types/node@25.6.0':
     dependencies:
       undici-types: 7.19.2
-    optional: true
 
   '@types/trusted-types@2.0.7': {}
 
@@ -3576,8 +3578,7 @@ snapshots:
 
   typescript@6.0.3: {}
 
-  undici-types@7.19.2:
-    optional: true
+  undici-types@7.19.2: {}
 
   unicorn-magic@0.4.0: {}
 


### PR DESCRIPTION
## Summary
- SvelteKit's auto-generated tsconfig declares `"types": ["node"]`, but `@types/node` wasn't a devDependency, so `pnpm lint:types` was emitting a `Cannot find type definition file for 'node'` warning
- Adds the missing devDependency; warning is gone locally

## Test plan
- [ ] CI lint passes with no svelte-check warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)