### PR TITLE
Populate 2026 season schedule

### DIFF
--- a/src/lib/data/base.ts
+++ b/src/lib/data/base.ts
@@ -1,6 +1,7 @@
 export interface Score {
   date: string;
   location: string;
+  name?: string;
   /**
    * - omitted/`undefined` — scheduled but not yet competed
    * - `null` — competed (e.g. exhibition) with no published score

--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -3,5 +3,79 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2026: SeasonScores = {
   year: '2026',
   endDate: '2026-08-08',
-  scores: [],
+  scores: [
+    {
+      date: '2026-06-27',
+      location: 'Alliance, OH',
+      name: 'Bluecoats Opening Night Community Celebration',
+    },
+    { date: '2026-07-02', location: 'Camarillo, CA', name: 'MidCal Showcase' },
+    {
+      date: '2026-07-03',
+      location: 'Sacramento, CA',
+      name: 'DCI Capital Classic',
+    },
+    { date: '2026-07-05', location: 'Stanford, CA', name: 'DCI West' },
+    {
+      date: '2026-07-09',
+      location: 'Santa Clarita, CA',
+      name: 'Gold Showcase',
+    },
+    {
+      date: '2026-07-10',
+      location: 'Walnut, CA',
+      name: 'Western Corps Connection',
+    },
+    {
+      date: '2026-07-11',
+      location: 'Pasadena, CA',
+      name: 'Drum Corps at the Rose Bowl',
+    },
+    {
+      date: '2026-07-13',
+      location: 'Mesa, AZ',
+      name: 'Drums Across the Desert',
+    },
+    { date: '2026-07-14', location: 'Albuquerque, NM', name: 'DCI New Mexico' },
+    { date: '2026-07-16', location: 'Denton, TX', name: 'DCI Denton' },
+    { date: '2026-07-17', location: 'Houston, TX', name: 'DCI Houston' },
+    {
+      date: '2026-07-18',
+      location: 'San Antonio, TX',
+      name: 'DCI Southwestern Championship',
+    },
+    { date: '2026-07-24', location: 'Nashville, TN', name: 'DCI Nashville' },
+    {
+      date: '2026-07-25',
+      location: 'Atlanta, GA',
+      name: 'DCI Southeastern Championship',
+    },
+    { date: '2026-07-26', location: 'Winston-Salem, NC', name: 'NightBEAT' },
+    {
+      date: '2026-07-30',
+      location: 'Lawrence, MA',
+      name: 'DCI East Coast Showcase',
+    },
+    {
+      date: '2026-07-31',
+      location: 'Allentown, PA',
+      name: 'DCI Eastern Classic',
+    },
+    { date: '2026-08-03', location: 'Akron, OH', name: 'Innovations in Brass' },
+    {
+      date: '2026-08-06',
+      location: 'Indianapolis, IN',
+      name: 'DCI World Championship Prelims',
+    },
+    {
+      date: '2026-08-07',
+      location: 'Indianapolis, IN',
+      name: 'DCI World Championship Semis',
+    },
+    {
+      date: '2026-08-08',
+      location: 'Indianapolis, IN',
+      name: 'DCI World Championship Finals',
+    },
+  ],
 };


### PR DESCRIPTION
## Summary
- Adds the 19-show 2026 DCI tour schedule (Opening Night through World Championship Prelims) as scheduled (no scores) entries in `src/lib/data/seasons/2026.ts`.
- Adds an optional `name` field to the `Score` interface so each event can carry its show name.

## Test plan
- [ ] `pnpm lint`
- [ ] `pnpm test`
- [ ] Spot-check the 2026 season renders on the Score History and Daily Rankings pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)