### PR TITLE
Add show titles to seasons and Daily Rankings table

### DIFF
--- a/src/lib/components/daily-rankings/Table.svelte
+++ b/src/lib/components/daily-rankings/Table.svelte
@@ -26,11 +26,17 @@
         scope="col"
         class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell"
       >
+        Show
+      </th>
+      <th
+        scope="col"
+        class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell"
+      >
         Score
       </th>
       <th
         scope="col"
-        class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
+        class="hidden px-3 py-3.5 text-left text-sm font-semibold text-gray-900 sm:table-cell"
       >
         Location
       </th>
@@ -40,7 +46,7 @@
     {#each rankings as ranking (ranking.year)}
       <tr>
         <td
-          class="py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-gray-900 sm:pl-6"
+          class="w-px py-4 pr-3 pl-4 text-sm font-medium whitespace-nowrap text-gray-900 sm:w-auto sm:pl-6"
         >
           {#if MEDALS[ranking.rank]}
             <span aria-hidden="true">{MEDALS[ranking.rank]}</span>
@@ -52,10 +58,17 @@
           {/if}
         </td>
         <td
-          class="px-3 py-4 text-sm font-medium whitespace-nowrap text-gray-900"
+          class="w-full max-w-0 px-3 py-4 text-sm text-gray-900 sm:w-auto sm:max-w-none sm:whitespace-nowrap"
         >
-          {ranking.year}
-          <dl class="font-normal md:hidden">
+          <div class="flex items-baseline gap-2">
+            <span class="font-medium">{ranking.year}</span>
+            {#if ranking.show}
+              <span class="min-w-0 truncate text-gray-500 sm:hidden">
+                {ranking.show}
+              </span>
+            {/if}
+          </div>
+          <dl class="font-normal sm:hidden">
             <dt class="sr-only">Score</dt>
             <dd class="mt-1 truncate text-gray-500">{ranking.score}</dd>
           </dl>
@@ -63,9 +76,16 @@
         <td
           class="hidden px-3 py-4 text-sm whitespace-nowrap text-gray-500 sm:table-cell"
         >
+          {ranking.show ?? ''}
+        </td>
+        <td
+          class="hidden px-3 py-4 text-sm whitespace-nowrap text-gray-500 sm:table-cell"
+        >
           {ranking.score}
         </td>
-        <td class="px-3 py-4 text-sm whitespace-nowrap text-gray-500">
+        <td
+          class="hidden px-3 py-4 text-sm whitespace-nowrap text-gray-500 sm:table-cell"
+        >
           {ranking.location}
           {#if ranking.daysOld}
             <div class="text-gray-400">

--- a/src/lib/data/base.ts
+++ b/src/lib/data/base.ts
@@ -14,5 +14,6 @@ export interface SeasonScores {
   year: string;
   color?: string;
   endDate: string;
+  show?: string;
   scores: Array<Score>;
 }

--- a/src/lib/data/seasons/1992.ts
+++ b/src/lib/data/seasons/1992.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_1992: SeasonScores = {
   year: '1992',
   endDate: '1992-08-15',
+  show: 'A Day in the Life',
   scores: [
     {
       date: '1992-06-13',

--- a/src/lib/data/seasons/1993.ts
+++ b/src/lib/data/seasons/1993.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_1993: SeasonScores = {
   year: '1993',
   endDate: '1993-08-21',
+  show: 'Standards in Blue: A Tribute to Dizzy Gillespie',
   scores: [
     {
       date: '1993-06-20',

--- a/src/lib/data/seasons/1994.ts
+++ b/src/lib/data/seasons/1994.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_1994: SeasonScores = {
   year: '1994',
   endDate: '1994-08-19',
+  show: 'Blues',
   scores: [
     {
       date: '1994-06-21',

--- a/src/lib/data/seasons/1995.ts
+++ b/src/lib/data/seasons/1995.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_1995: SeasonScores = {
   year: '1995',
   endDate: '1995-08-12',
+  show: 'Homefront: 1945',
   scores: [
     {
       date: '1995-07-01',

--- a/src/lib/data/seasons/1996.ts
+++ b/src/lib/data/seasons/1996.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_1996: SeasonScores = {
   year: '1996',
   endDate: '1996-08-17',
+  show: 'American Celebrations',
   scores: [
     {
       date: '1996-06-28',

--- a/src/lib/data/seasons/1997.ts
+++ b/src/lib/data/seasons/1997.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_1997: SeasonScores = {
   year: '1997',
   endDate: '1997-08-16',
+  show: "Midnight Blue... Jazz After Dark, The Bluecoats' Way",
   scores: [
     {
       date: '1997-06-23',

--- a/src/lib/data/seasons/1998.ts
+++ b/src/lib/data/seasons/1998.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_1998: SeasonScores = {
   year: '1998',
   endDate: '1998-08-15',
+  show: 'The Four Seasons of Jazz',
   scores: [
     {
       date: '1998-06-23',

--- a/src/lib/data/seasons/1999.ts
+++ b/src/lib/data/seasons/1999.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_1999: SeasonScores = {
   year: '1999',
   endDate: '1999-08-14',
+  show: 'Music of Chick Corea',
   scores: [
     {
       date: '1999-06-26',

--- a/src/lib/data/seasons/2000.ts
+++ b/src/lib/data/seasons/2000.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2000: SeasonScores = {
   year: '2000',
   endDate: '2000-08-12',
+  show: 'Threshold',
   scores: [
     {
       date: '2000-06-23',

--- a/src/lib/data/seasons/2001.ts
+++ b/src/lib/data/seasons/2001.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2001: SeasonScores = {
   year: '2001',
   endDate: '2001-08-11',
+  show: 'Latin Sketches',
   scores: [
     {
       date: '2001-06-16',

--- a/src/lib/data/seasons/2002.ts
+++ b/src/lib/data/seasons/2002.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2002: SeasonScores = {
   year: '2002',
   endDate: '2002-08-10',
+  show: 'Urban Dances',
   scores: [
     {
       date: '2002-06-15',

--- a/src/lib/data/seasons/2003.ts
+++ b/src/lib/data/seasons/2003.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2003: SeasonScores = {
   year: '2003',
   endDate: '2003-08-09',
+  show: 'Capture and Escape',
   scores: [
     {
       date: '2003-06-18',

--- a/src/lib/data/seasons/2004.ts
+++ b/src/lib/data/seasons/2004.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2004: SeasonScores = {
   year: '2004',
   endDate: '2004-08-07',
+  show: 'Mood Swings',
   scores: [
     {
       date: '2004-06-19',

--- a/src/lib/data/seasons/2005.ts
+++ b/src/lib/data/seasons/2005.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2005: SeasonScores = {
   year: '2005',
   endDate: '2005-08-13',
+  show: 'Caravan',
   scores: [
     {
       date: '2005-06-17',

--- a/src/lib/data/seasons/2006.ts
+++ b/src/lib/data/seasons/2006.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2006: SeasonScores = {
   year: '2006',
   endDate: '2006-08-12',
+  show: 'Connexus',
   scores: [
     {
       date: '2006-06-17',

--- a/src/lib/data/seasons/2007.ts
+++ b/src/lib/data/seasons/2007.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2007: SeasonScores = {
   year: '2007',
   endDate: '2007-08-11',
+  show: 'Criminal',
   scores: [
     {
       date: '2007-06-16',

--- a/src/lib/data/seasons/2008.ts
+++ b/src/lib/data/seasons/2008.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2008: SeasonScores = {
   year: '2008',
   endDate: '2008-08-09',
+  show: 'The Knockout',
   scores: [
     {
       date: '2008-06-21',

--- a/src/lib/data/seasons/2009.ts
+++ b/src/lib/data/seasons/2009.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2009: SeasonScores = {
   year: '2009',
   endDate: '2009-08-08',
+  show: 'Imagine',
   scores: [
     {
       date: '2009-06-23',

--- a/src/lib/data/seasons/2010.ts
+++ b/src/lib/data/seasons/2010.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2010: SeasonScores = {
   year: '2010',
   endDate: '2010-08-14',
+  show: 'Metropolis: The Future is Now',
   scores: [
     {
       date: '2010-06-21',

--- a/src/lib/data/seasons/2011.ts
+++ b/src/lib/data/seasons/2011.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2011: SeasonScores = {
   year: '2011',
   endDate: '2011-08-13',
+  show: 'Brave New World',
   scores: [
     {
       date: '2011-06-18',

--- a/src/lib/data/seasons/2012.ts
+++ b/src/lib/data/seasons/2012.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2012: SeasonScores = {
   year: '2012',
   endDate: '2012-08-11',
+  show: 'Unmasqued',
   scores: [
     {
       date: '2012-06-16',

--- a/src/lib/data/seasons/2013.ts
+++ b/src/lib/data/seasons/2013.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2013: SeasonScores = {
   year: '2013',
   endDate: '2013-08-10',
+  show: '...to Look for America',
   scores: [
     {
       date: '2013-06-21',

--- a/src/lib/data/seasons/2014.ts
+++ b/src/lib/data/seasons/2014.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2014: SeasonScores = {
   year: '2014',
   endDate: '2014-08-09',
+  show: 'Tilt',
   scores: [
     {
       date: '2014-06-21',

--- a/src/lib/data/seasons/2015.ts
+++ b/src/lib/data/seasons/2015.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2015: SeasonScores = {
   year: '2015',
   endDate: '2015-08-08',
+  show: 'Kinetic Noise',
   scores: [
     {
       date: '2015-06-17',

--- a/src/lib/data/seasons/2016.ts
+++ b/src/lib/data/seasons/2016.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2016: SeasonScores = {
   year: '2016',
   endDate: '2016-08-13',
+  show: 'Down Side Up',
   scores: [
     {
       date: '2016-06-23',

--- a/src/lib/data/seasons/2017.ts
+++ b/src/lib/data/seasons/2017.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2017: SeasonScores = {
   year: '2017',
   endDate: '2017-08-12',
+  show: 'Jagged Line',
   scores: [
     {
       date: '2017-06-22',

--- a/src/lib/data/seasons/2018.ts
+++ b/src/lib/data/seasons/2018.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2018: SeasonScores = {
   year: '2018',
   endDate: '2018-08-11',
+  show: 'Session 44',
   scores: [
     {
       date: '2018-06-21',

--- a/src/lib/data/seasons/2019.ts
+++ b/src/lib/data/seasons/2019.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2019: SeasonScores = {
   year: '2019',
   endDate: '2019-08-10',
+  show: 'The Bluecoats',
   scores: [
     {
       date: '2019-06-20',

--- a/src/lib/data/seasons/2022.ts
+++ b/src/lib/data/seasons/2022.ts
@@ -4,6 +4,7 @@ export const SEASON_2022: SeasonScores = {
   year: '2022',
   color: '#ec4899', // pink-500
   endDate: '2022-08-13',
+  show: 'Riffs and Revelations',
   scores: [
     {
       date: '2022-06-28',

--- a/src/lib/data/seasons/2023.ts
+++ b/src/lib/data/seasons/2023.ts
@@ -4,6 +4,7 @@ export const SEASON_2023: SeasonScores = {
   year: '2023',
   color: '#34d399', // emerald-400
   endDate: '2023-08-12',
+  show: 'The Garden of Love',
   scores: [
     {
       date: '2023-07-05',

--- a/src/lib/data/seasons/2024.ts
+++ b/src/lib/data/seasons/2024.ts
@@ -4,6 +4,7 @@ export const SEASON_2024: SeasonScores = {
   year: '2024',
   color: '#dc2626', // red-600
   endDate: '2024-08-10',
+  show: 'Change Is Everything',
   scores: [
     {
       date: '2024-07-02',

--- a/src/lib/data/seasons/2025.ts
+++ b/src/lib/data/seasons/2025.ts
@@ -6,6 +6,7 @@ export const SEASON_2025: SeasonScores = {
   year: '2025',
   color: COLOR_OPTIONS[Math.floor(Math.random() * COLOR_OPTIONS.length)],
   endDate: '2025-08-09',
+  show: 'The Observer Effect',
   scores: [
     {
       date: '2025-07-06',

--- a/src/lib/utils/daily-rankings.ts
+++ b/src/lib/utils/daily-rankings.ts
@@ -6,6 +6,7 @@ export interface DailyRankingsItem {
   location: Score['location'];
   rank: number;
   score: number;
+  show: SeasonScores['show'];
   year: SeasonScores['year'];
 }
 
@@ -33,6 +34,7 @@ function rankingsItemForSelectedDay(
       ) - selectedDay,
     location: latestScore.location,
     score: latestScore.score,
+    show: season.show,
     year: season.year,
   };
 }


### PR DESCRIPTION
## Summary
- Adds optional `show` property to `SeasonScores`, populated for 1992–2025 from the [Bluecoats Wikipedia repertoire table](https://en.wikipedia.org/wiki/Bluecoats_Drum_and_Bugle_Corps).
- Renders a new "Show" column in the Daily Rankings table between Year and Score on desktop.
- On mobile, the show title appears inline next to the year (bold) with ellipsis truncation; rank column shrinks to its content while year/show fills the rest of the row.

## Test plan
- [x] Daily Rankings table shows the Show column between Year and Score on desktop
- [x] On mobile, year (bold) + show appear on one line, truncating with an ellipsis for long titles
- [x] Years without a known show (e.g. 1978, 1980–1991) render with an empty Show cell
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)