### PR TITLE
chore: promote common git/PR commands to shared permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,6 +14,11 @@
       "Bash(git add *)",
       "Bash(git commit *)",
       "Bash(git push *)",
+      "Bash(git pull *)",
+      "Bash(git fetch *)",
+      "Bash(git branch *)",
+      "Bash(git stash *)",
+      "Bash(gh pr *)",
       "mcp__chrome-devtools__*",
       "mcp__svelte__*"
     ]


### PR DESCRIPTION
Promotes everyday git/PR workflow commands from local-only settings into the checked-in `.claude/settings.json`, so every contributor gets them without re-approving.

## What moved into shared settings

Added alongside the existing `git checkout/add/commit/push` allowances:

- `Bash(git pull *)`
- `Bash(git fetch *)`
- `Bash(git branch *)`
- `Bash(git stash *)`
- `Bash(gh pr *)`

## Why

These are generic, everyday commands with no project-specific or sensitive scope — the natural companions to the git permissions already shared. `Bash(gh api *)` was intentionally **left** in local settings since it grants the broadest GitHub API access (including mutations).

No code or behavior changes; permissions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)