### PR TITLE
fix: move daily-ranking medal emoji to follow the year

### DIFF
--- a/src/lib/components/daily-ranking/Table.svelte
+++ b/src/lib/components/daily-ranking/Table.svelte
@@ -87,15 +87,15 @@
           class="w-full max-w-0 px-3 py-3 align-middle sm:w-auto sm:max-w-none sm:whitespace-nowrap"
         >
           <div class="text-sm font-semibold text-gray-900 tabular-nums">
-            {ranking.year}
+            {ranking.year}{#if medal}<span
+                class="ml-1.5"
+                role="img"
+                aria-label={MEDAL_LABEL[medal]}>{MEDAL_EMOJI[medal]}</span
+              >{/if}
           </div>
           {#if ranking.show}
             <div class="mt-0.5 truncate text-xs text-gray-500 sm:hidden">
-              {ranking.show}{#if medal}<span
-                  class="ml-1"
-                  role="img"
-                  aria-label={MEDAL_LABEL[medal]}>{MEDAL_EMOJI[medal]}</span
-                >{/if}
+              {ranking.show}
             </div>
           {/if}
         </td>
@@ -103,11 +103,6 @@
           class="hidden px-3 py-3 align-middle text-sm whitespace-nowrap text-gray-600 sm:table-cell"
         >
           {ranking.show ?? '—'}
-          {#if medal}
-            <span class="ml-1.5" role="img" aria-label={MEDAL_LABEL[medal]}
-              >{MEDAL_EMOJI[medal]}</span
-            >
-          {/if}
         </td>
         <td
           class="hidden px-3 py-3 align-middle text-sm whitespace-nowrap text-gray-600 sm:table-cell"


### PR DESCRIPTION
## Summary

On mobile, the medal emoji (🥇/🥈/🥉) shown in the Daily Ranking table was appended to the show name, which renders in a `truncate`d sub-line under the year. When the show name is long, the truncation cut the medal off entirely. The desktop "Show" column carried a second copy of the same emoji.

This moves the single medal emoji to follow the **year** instead — which is short and never truncates — so medals render consistently on both mobile and desktop.

## Changes

- `daily-ranking/Table.svelte`: append the medal to the year line; remove it from the mobile show sub-line and from the desktop "Show" column.

The `medal` derivation and the `MEDAL_*` maps are unchanged and still drive the relative-bar color.

## Verification

- Svelte autofixer: no issues
- `pnpm lint` (eslint, stylelint, svelte-check, knip, prettier): pass
- `pnpm test:unit`: 68/68 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)