### PR TITLE
Add Tour page (per-season detail)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 
 # claude code local overrides
 /.claude/settings.local.json
+
+# superpowers design specs / plans (local only)
+/docs/superpowers/

--- a/src/lib/components/nav/MobileTabBar.svelte
+++ b/src/lib/components/nav/MobileTabBar.svelte
@@ -7,7 +7,7 @@
     if (kind === 'history')
       return 'M3 19h18 M5 17V9 M10 17V5 M15 17v-6 M20 17v-9';
     if (kind === 'tour')
-      return 'M12 21s-6-5.3-6-10a6 6 0 1 1 12 0c0 4.7-6 10-6 10z M12 11a2 2 0 1 0 0-4 2 2 0 0 0 0 4z';
+      return 'M5 12h14 M5 12l-2-2 2-2 M5 12l-2 2 2 2 M17 6a2 2 0 1 0 4 0 2 2 0 1 0-4 0 M17 18a2 2 0 1 0 4 0 2 2 0 1 0-4 0';
     return 'M3 5h18v14H3z M3 9h18 M8 5v4 M16 5v4';
   }
 </script>

--- a/src/lib/components/nav/MobileTabBar.svelte
+++ b/src/lib/components/nav/MobileTabBar.svelte
@@ -6,12 +6,14 @@
   function iconPath(kind: NavIconKind): string {
     if (kind === 'history')
       return 'M3 19h18 M5 17V9 M10 17V5 M15 17v-6 M20 17v-9';
+    if (kind === 'tour')
+      return 'M12 21s-6-5.3-6-10a6 6 0 1 1 12 0c0 4.7-6 10-6 10z M12 11a2 2 0 1 0 0-4 2 2 0 0 0 0 4z';
     return 'M3 5h18v14H3z M3 9h18 M8 5v4 M16 5v4';
   }
 </script>
 
 <nav
-  class="absolute inset-x-0 bottom-0 z-20 grid grid-cols-2 border-t border-gray-200 bg-white/90 px-1 pt-1.5 pb-[calc(0.625rem+env(safe-area-inset-bottom,0))] backdrop-blur-lg backdrop-saturate-150 md:hidden"
+  class="absolute inset-x-0 bottom-0 z-20 grid grid-cols-3 border-t border-gray-200 bg-white/90 px-1 pt-1.5 pb-[calc(0.625rem+env(safe-area-inset-bottom,0))] backdrop-blur-lg backdrop-saturate-150 md:hidden"
   aria-label="Primary"
 >
   {#each NAV_ITEMS as item (item.href)}

--- a/src/lib/components/nav/types.ts
+++ b/src/lib/components/nav/types.ts
@@ -1,9 +1,9 @@
-export type NavIconKind = 'history' | 'daily';
+export type NavIconKind = 'history' | 'daily' | 'tour';
 
 export interface NavItem {
   label: string;
   shortLabel: string;
-  href: '/' | '/daily-ranking';
+  href: '/' | '/daily-ranking' | '/tour';
   icon: NavIconKind;
 }
 
@@ -15,4 +15,5 @@ export const NAV_ITEMS: ReadonlyArray<NavItem> = [
     href: '/daily-ranking',
     icon: 'daily',
   },
+  { label: 'Tour', shortLabel: 'Tour', href: '/tour', icon: 'tour' },
 ];

--- a/src/lib/components/tour/SeasonPicker.svelte
+++ b/src/lib/components/tour/SeasonPicker.svelte
@@ -32,7 +32,7 @@
   <div class="flex items-center gap-2">
     <button
       type="button"
-      class="inline-flex h-9 items-center gap-1 rounded-md border border-gray-200 px-2.5 text-sm font-medium text-gray-700 enabled:hover:bg-gray-50 disabled:opacity-40"
+      class="inline-flex h-9 items-center gap-1 rounded-md border border-gray-200 px-2.5 text-sm font-medium text-gray-700 enabled:hover:bg-gray-50 disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:outline-none"
       onclick={() => prev && onChange(prev.year)}
       disabled={!prev}
       aria-label="Previous season"
@@ -72,7 +72,7 @@
 
     <button
       type="button"
-      class="inline-flex h-9 items-center gap-1 rounded-md border border-gray-200 px-2.5 text-sm font-medium text-gray-700 enabled:hover:bg-gray-50 disabled:opacity-40"
+      class="inline-flex h-9 items-center gap-1 rounded-md border border-gray-200 px-2.5 text-sm font-medium text-gray-700 enabled:hover:bg-gray-50 disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:outline-none"
       onclick={() => next && onChange(next.year)}
       disabled={!next}
       aria-label="Next season"
@@ -95,7 +95,7 @@
       {@const champ = season.placement === 1}
       <button
         type="button"
-        class="h-7 rounded px-1.5 text-xs font-semibold tabular-nums transition-colors {active
+        class="h-7 rounded px-1.5 text-xs font-semibold tabular-nums transition-colors focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:outline-none {active
           ? 'bg-brand-600 text-white'
           : champ
             ? 'bg-gold-100 text-gold-700 hover:bg-gold-400/30'

--- a/src/lib/components/tour/SeasonPicker.svelte
+++ b/src/lib/components/tour/SeasonPicker.svelte
@@ -20,11 +20,10 @@
   const next = $derived(index < ordered.length - 1 ? ordered[index + 1] : null);
 
   function optionLabel(season: SeasonScores): string {
-    const champ = season.placement === 1 ? ' ★' : '';
     const progress = isInProgress(season) ? ' · in progress' : '';
     const score = finalsOrLatestScore(season);
     const scoreText = score !== null ? ` — ${score.toFixed(3)}` : '';
-    return `${season.year}${champ}${progress}${scoreText}`;
+    return `${season.year}${progress}${scoreText}`;
   }
 </script>
 

--- a/src/lib/components/tour/SeasonPicker.svelte
+++ b/src/lib/components/tour/SeasonPicker.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+  import type { SeasonScores } from '$data/base';
+  import { isInProgress, finalsOrLatestScore } from '$lib/utils/tour';
+
+  let {
+    seasons,
+    year,
+    onChange,
+  }: {
+    seasons: SeasonScores[];
+    year: string;
+    onChange: (year: string) => void;
+  } = $props();
+
+  const ordered = $derived(
+    [...seasons].sort((a, b) => Number(a.year) - Number(b.year)),
+  );
+  const index = $derived(ordered.findIndex((s) => s.year === year));
+  const prev = $derived(index > 0 ? ordered[index - 1] : null);
+  const next = $derived(index < ordered.length - 1 ? ordered[index + 1] : null);
+
+  function optionLabel(season: SeasonScores): string {
+    const champ = season.placement === 1 ? ' ★' : '';
+    const progress = isInProgress(season) ? ' · in progress' : '';
+    const score = finalsOrLatestScore(season);
+    const scoreText = score !== null ? ` — ${score.toFixed(3)}` : '';
+    return `${season.year}${champ}${progress}${scoreText}`;
+  }
+</script>
+
+<div class="flex flex-col gap-3">
+  <div class="flex items-center gap-2">
+    <button
+      type="button"
+      class="inline-flex h-9 items-center gap-1 rounded-md border border-gray-200 px-2.5 text-sm font-medium text-gray-700 enabled:hover:bg-gray-50 disabled:opacity-40"
+      onclick={() => prev && onChange(prev.year)}
+      disabled={!prev}
+      aria-label="Previous season"
+    >
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.25"
+        class="size-4"
+        aria-hidden="true"><path d="M15 18l-6-6 6-6" /></svg
+      >
+      {#if prev}<span class="tabular-nums">{prev.year}</span>{/if}
+    </button>
+
+    <div class="relative flex-1">
+      <label class="sr-only" for="tour-season">Season</label>
+      <select
+        id="tour-season"
+        class="h-9 w-full appearance-none rounded-md border border-gray-200 bg-white pr-9 pl-3 text-sm font-semibold tabular-nums text-gray-900 focus:border-brand-500 focus:outline-none"
+        value={year}
+        onchange={(e) => onChange(e.currentTarget.value)}
+      >
+        {#each [...ordered].reverse() as season (season.year)}
+          <option value={season.year}>{optionLabel(season)}</option>
+        {/each}
+      </select>
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.5"
+        class="pointer-events-none absolute top-1/2 right-3 size-3 -translate-y-1/2 text-gray-400"
+        aria-hidden="true"><path d="M6 9l6 6 6-6" /></svg
+      >
+    </div>
+
+    <button
+      type="button"
+      class="inline-flex h-9 items-center gap-1 rounded-md border border-gray-200 px-2.5 text-sm font-medium text-gray-700 enabled:hover:bg-gray-50 disabled:opacity-40"
+      onclick={() => next && onChange(next.year)}
+      disabled={!next}
+      aria-label="Next season"
+    >
+      {#if next}<span class="tabular-nums">{next.year}</span>{/if}
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2.25"
+        class="size-4"
+        aria-hidden="true"><path d="M9 6l6 6-6 6" /></svg
+      >
+    </button>
+  </div>
+
+  <div class="flex flex-wrap gap-1">
+    {#each ordered as season (season.year)}
+      {@const active = season.year === year}
+      {@const champ = season.placement === 1}
+      <button
+        type="button"
+        class="h-7 rounded px-1.5 text-xs font-semibold tabular-nums transition-colors {active
+          ? 'bg-brand-600 text-white'
+          : champ
+            ? 'bg-gold-100 text-gold-700 hover:bg-gold-400/30'
+            : 'bg-gray-100 text-gray-500 hover:bg-gray-200'}"
+        onclick={() => onChange(season.year)}
+        aria-label="{season.year} season"
+        aria-current={active ? 'true' : undefined}
+      >
+        {season.year.slice(2)}
+      </button>
+    {/each}
+  </div>
+</div>

--- a/src/lib/components/tour/TourLog.svelte
+++ b/src/lib/components/tour/TourLog.svelte
@@ -26,12 +26,12 @@
       class="border-b border-gray-200 text-left text-[11px] font-semibold tracking-wider text-gray-500 uppercase"
     >
       <th scope="col" class="py-3 pr-3 pl-4 whitespace-nowrap sm:pl-6">Date</th>
-      <th scope="col" class="hidden px-3 py-3 whitespace-nowrap sm:table-cell">
+      <th scope="col" class="hidden px-3 py-3 whitespace-nowrap lg:table-cell">
         Day
       </th>
       <th scope="col" class="px-3 py-3">Event</th>
       <th scope="col" class="px-3 py-3 text-right whitespace-nowrap">Score</th>
-      <th scope="col" class="hidden px-3 py-3 whitespace-nowrap lg:table-cell">
+      <th scope="col" class="hidden px-3 py-3 whitespace-nowrap sm:table-cell">
         Rank then
       </th>
       <th scope="col" class="px-3 py-3 whitespace-nowrap">Rank now</th>
@@ -52,7 +52,7 @@
           {formatDate(row.date)}
         </td>
         <td
-          class="hidden px-3 py-3 align-middle text-sm whitespace-nowrap text-gray-400 tabular-nums sm:table-cell"
+          class="hidden px-3 py-3 align-middle text-sm whitespace-nowrap text-gray-400 tabular-nums lg:table-cell"
         >
           {row.daysBeforeFinals}d
         </td>
@@ -77,7 +77,7 @@
           {/if}
         </td>
         <td
-          class="hidden px-3 py-3 align-middle whitespace-nowrap lg:table-cell"
+          class="hidden px-3 py-3 align-middle whitespace-nowrap sm:table-cell"
         >
           {#if row.rankThen !== null}
             <span

--- a/src/lib/components/tour/TourLog.svelte
+++ b/src/lib/components/tour/TourLog.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+  import { DateTime } from 'luxon';
+  import type { TourLogRow } from '$lib/utils/tour';
+
+  let { rows }: { rows: TourLogRow[] } = $props();
+
+  function formatDate(iso: string): string {
+    return DateTime.fromISO(iso).toFormat('LLL d');
+  }
+
+  function rankClass(rank: number): string {
+    if (rank === 1)
+      return 'bg-amber-100 text-amber-900 ring-1 ring-inset ring-amber-300';
+    if (rank === 2)
+      return 'bg-slate-100 text-slate-700 ring-1 ring-inset ring-slate-300';
+    if (rank === 3)
+      return 'bg-orange-50 text-orange-800 ring-1 ring-inset ring-orange-200';
+    return 'bg-gray-100 text-gray-600';
+  }
+</script>
+
+<table class="min-w-full">
+  <thead class="bg-gray-50">
+    <tr
+      class="border-b border-gray-200 text-left text-[11px] font-semibold tracking-wider text-gray-500 uppercase"
+    >
+      <th scope="col" class="py-3 pr-3 pl-4 whitespace-nowrap sm:pl-6">Date</th>
+      <th scope="col" class="hidden px-3 py-3 whitespace-nowrap sm:table-cell">
+        Day
+      </th>
+      <th scope="col" class="px-3 py-3">Event</th>
+      <th scope="col" class="px-3 py-3 text-right whitespace-nowrap">Score</th>
+      <th scope="col" class="hidden px-3 py-3 whitespace-nowrap lg:table-cell">
+        Rank then
+      </th>
+      <th scope="col" class="px-3 py-3 whitespace-nowrap">Rank now</th>
+      <th
+        scope="col"
+        class="hidden px-3 py-3 pr-6 whitespace-nowrap lg:table-cell"
+      >
+        Δ
+      </th>
+    </tr>
+  </thead>
+  <tbody class="divide-y divide-gray-200 bg-white">
+    {#each rows as row (row.date)}
+      <tr class="hover:bg-gray-50">
+        <td
+          class="py-3 pr-3 pl-4 align-middle text-sm font-semibold whitespace-nowrap text-gray-900 sm:pl-6"
+        >
+          {formatDate(row.date)}
+        </td>
+        <td
+          class="hidden px-3 py-3 align-middle text-sm whitespace-nowrap text-gray-400 tabular-nums sm:table-cell"
+        >
+          {row.daysBeforeFinals}d
+        </td>
+        <td class="px-3 py-3 align-middle">
+          <div class="text-sm font-medium text-gray-900">
+            {row.name ?? row.location}
+          </div>
+          {#if row.name}
+            <div class="text-xs text-gray-400">{row.location}</div>
+          {/if}
+          {#if row.score === null}
+            <div class="text-xs text-gray-400">Exhibition · no score</div>
+          {/if}
+        </td>
+        <td
+          class="px-3 py-3 text-right align-middle text-sm font-semibold whitespace-nowrap text-gray-900 tabular-nums"
+        >
+          {#if row.score !== null}
+            {row.score.toFixed(3)}
+          {:else}
+            <span class="text-gray-300">—</span>
+          {/if}
+        </td>
+        <td
+          class="hidden px-3 py-3 align-middle whitespace-nowrap lg:table-cell"
+        >
+          {#if row.rankThen !== null}
+            <span
+              class="inline-flex h-6 min-w-7 items-center justify-center rounded-md px-1.5 text-xs font-semibold tabular-nums {rankClass(
+                row.rankThen,
+              )}">#{row.rankThen}</span
+            >
+          {:else}
+            <span class="text-xs text-gray-300">—</span>
+          {/if}
+        </td>
+        <td class="px-3 py-3 align-middle whitespace-nowrap">
+          {#if row.rankNow !== null}
+            <span
+              class="inline-flex h-6 min-w-7 items-center justify-center rounded-md px-1.5 text-xs font-semibold tabular-nums {rankClass(
+                row.rankNow,
+              )}">#{row.rankNow}</span
+            >
+          {:else}
+            <span class="text-xs text-gray-400">no score</span>
+          {/if}
+        </td>
+        <td
+          class="hidden px-3 py-3 pr-6 align-middle whitespace-nowrap lg:table-cell"
+        >
+          {#if row.rankThen !== null && row.rankNow !== null}
+            {@const delta = row.rankNow - row.rankThen}
+            {#if delta === 0}
+              <span class="text-xs text-gray-400">holds</span>
+            {:else}
+              <span
+                class="text-xs font-semibold {delta > 0
+                  ? 'text-red-700'
+                  : 'text-green-700'}"
+              >
+                {delta > 0 ? '↓' : '↑'}
+                {Math.abs(delta)}
+              </span>
+            {/if}
+          {:else}
+            <span class="text-xs text-gray-300">—</span>
+          {/if}
+        </td>
+      </tr>
+    {/each}
+  </tbody>
+</table>

--- a/src/lib/components/tour/TourLog.svelte
+++ b/src/lib/components/tour/TourLog.svelte
@@ -44,7 +44,7 @@
     </tr>
   </thead>
   <tbody class="divide-y divide-gray-200 bg-white">
-    {#each rows as row (row.date)}
+    {#each rows as row, i (i)}
       <tr class="hover:bg-gray-50">
         <td
           class="py-3 pr-3 pl-4 align-middle text-sm font-semibold whitespace-nowrap text-gray-900 sm:pl-6"

--- a/src/lib/components/tour/TourLog.svelte
+++ b/src/lib/components/tour/TourLog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { DateTime } from 'luxon';
   import type { TourLogRow } from '$lib/utils/tour';
+  import { ordinalSuffix } from '$lib/utils/ordinal';
 
   let { rows }: { rows: TourLogRow[] } = $props();
 
@@ -80,6 +81,9 @@
         >
           {#if row.rankThen !== null}
             <span
+              aria-label="ranked {row.rankThen}{ordinalSuffix(
+                row.rankThen,
+              )} at the time"
               class="inline-flex h-6 min-w-7 items-center justify-center rounded-md px-1.5 text-xs font-semibold tabular-nums {rankClass(
                 row.rankThen,
               )}">#{row.rankThen}</span
@@ -91,12 +95,15 @@
         <td class="px-3 py-3 align-middle whitespace-nowrap">
           {#if row.rankNow !== null}
             <span
+              aria-label="ranked {row.rankNow}{ordinalSuffix(
+                row.rankNow,
+              )} today"
               class="inline-flex h-6 min-w-7 items-center justify-center rounded-md px-1.5 text-xs font-semibold tabular-nums {rankClass(
                 row.rankNow,
               )}">#{row.rankNow}</span
             >
           {:else}
-            <span class="text-xs text-gray-400">no score</span>
+            <span class="text-xs text-gray-300">—</span>
           {/if}
         </td>
         <td
@@ -108,6 +115,9 @@
               <span class="text-xs text-gray-400">holds</span>
             {:else}
               <span
+                aria-label={delta > 0
+                  ? `dropped ${Math.abs(delta)} ${Math.abs(delta) === 1 ? 'place' : 'places'}`
+                  : `improved ${Math.abs(delta)} ${Math.abs(delta) === 1 ? 'place' : 'places'}`}
                 class="text-xs font-semibold {delta > 0
                   ? 'text-red-700'
                   : 'text-green-700'}"

--- a/src/lib/components/tour/TourStats.svelte
+++ b/src/lib/components/tour/TourStats.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import Card from '$components/shared/Card.svelte';
+  import type { TourSummary } from '$lib/utils/tour';
+
+  let { summary, inProgress }: { summary: TourSummary; inProgress: boolean } =
+    $props();
+</script>
+
+<div class="grid grid-cols-2 gap-4 lg:grid-cols-4">
+  <Card>
+    <div class="text-xs font-medium tracking-wide text-gray-500 uppercase">
+      Season high
+    </div>
+    <div class="mt-1 text-2xl font-semibold tabular-nums text-gray-900">
+      {summary.seasonHigh !== null ? summary.seasonHigh.toFixed(3) : '—'}
+    </div>
+    <div class="mt-0.5 text-xs text-gray-400">
+      {inProgress
+        ? 'so far'
+        : summary.finalsRank !== null
+          ? `Finals · #${summary.finalsRank} all-time`
+          : 'best of tour'}
+    </div>
+  </Card>
+  <Card>
+    <div class="text-xs font-medium tracking-wide text-gray-500 uppercase">
+      Climb across tour
+    </div>
+    <div class="mt-1 text-2xl font-semibold tabular-nums text-gray-900">
+      {summary.climb !== null ? `+${summary.climb.toFixed(2)}` : '—'}
+    </div>
+    <div class="mt-0.5 text-xs text-gray-400">first to latest score</div>
+  </Card>
+  <Card>
+    <div class="text-xs font-medium tracking-wide text-gray-500 uppercase">
+      Top-5 days
+    </div>
+    <div class="mt-1 text-2xl font-semibold tabular-nums text-gray-900">
+      {summary.topFiveDays}
+    </div>
+    <div class="mt-0.5 text-xs text-gray-400">shows ranked top 5 all-time</div>
+  </Card>
+  <Card>
+    <div class="text-xs font-medium tracking-wide text-gray-500 uppercase">
+      All-time #1 days
+    </div>
+    <div class="mt-1 text-2xl font-semibold tabular-nums text-gray-900">
+      {summary.allTimeBestDays}
+    </div>
+    <div class="mt-0.5 text-xs text-gray-400">scores still #1 today</div>
+  </Card>
+</div>

--- a/src/lib/components/tour/TourStats.svelte
+++ b/src/lib/components/tour/TourStats.svelte
@@ -27,7 +27,9 @@
       Climb across tour
     </div>
     <div class="mt-1 text-2xl font-semibold tabular-nums text-gray-900">
-      {summary.climb !== null ? `+${summary.climb.toFixed(2)}` : '—'}
+      {summary.climb !== null
+        ? `${summary.climb >= 0 ? '+' : ''}${summary.climb.toFixed(2)}`
+        : '—'}
     </div>
     <div class="mt-0.5 text-xs text-gray-400">first to latest score</div>
   </Card>

--- a/src/lib/utils/tour.ts
+++ b/src/lib/utils/tour.ts
@@ -1,0 +1,52 @@
+import { DateTime } from 'luxon';
+import type { SeasonScores } from '$data/base';
+import { FINALS_ZONE } from './time';
+
+export interface TourStop {
+  date: string;
+  location: string;
+  name?: string;
+  daysBeforeFinals: number;
+  /** `null` = competed with no registered score (e.g. exhibition). */
+  score: number | null;
+}
+
+function daysBeforeFinals(season: SeasonScores, date: string): number {
+  const finals = DateTime.fromISO(season.endDate, { zone: FINALS_ZONE });
+  const day = DateTime.fromISO(date, { zone: FINALS_ZONE });
+  return Math.ceil(finals.diff(day, 'days').days);
+}
+
+/**
+ * Per-show records for a season, earliest → finals. Includes shows that were
+ * competed with no registered score (`score: null`); excludes shows that have
+ * not yet been competed (`score` omitted/`undefined`).
+ */
+export function buildTour(season: SeasonScores): TourStop[] {
+  return season.scores
+    .filter((s) => s.score === null || typeof s.score === 'number')
+    .map((s) => ({
+      date: s.date,
+      location: s.location,
+      name: s.name,
+      daysBeforeFinals: daysBeforeFinals(season, s.date),
+      score: s.score ?? null,
+    }));
+}
+
+/** Latest numeric score with at least `day` days before finals, else null. */
+export function scoreAsOfDay(season: SeasonScores, day: number): number | null {
+  let result: number | null = null;
+  for (const s of season.scores) {
+    if (typeof s.score !== 'number') continue;
+    if (daysBeforeFinals(season, s.date) >= day) result = s.score;
+  }
+  return result;
+}
+
+/** A season with both competed shows and still-scheduled (uncompeted) shows. */
+export function isInProgress(season: SeasonScores): boolean {
+  const hasScheduled = season.scores.some((s) => s.score === undefined);
+  const hasNumeric = season.scores.some((s) => typeof s.score === 'number');
+  return hasScheduled && hasNumeric;
+}

--- a/src/lib/utils/tour.ts
+++ b/src/lib/utils/tour.ts
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon';
 import type { SeasonScores } from '$data/base';
 import { FINALS_ZONE } from './time';
+import { ordinalSuffix } from './ordinal';
 
 export interface TourStop {
   date: string;
@@ -112,4 +113,95 @@ export function buildTourLog(
       rankNow: rankNow(seasons, stop.daysBeforeFinals, stop.score, season.year),
     };
   });
+}
+
+export interface TourSummary {
+  seasonHigh: number | null;
+  /** Last numeric score − first numeric score. */
+  climb: number | null;
+  /** Shows whose rank-now is 5 or better. */
+  topFiveDays: number;
+  /** Shows whose rank-now is exactly 1 (still the all-time best at that day). */
+  allTimeBestDays: number;
+  /** Finals-night score (day 0), or null if the season has not reached finals. */
+  finalsScore: number | null;
+  /** All-time rank of this season's finals score, or null when there is none. */
+  finalsRank: number | null;
+}
+
+/** The numeric score on finals night (0 days before finals), else null. */
+function finalsScore(season: SeasonScores): number | null {
+  const finalsStops = buildTour(season).filter(
+    (s) => s.daysBeforeFinals === 0 && s.score !== null,
+  );
+  return finalsStops.length ? finalsStops[finalsStops.length - 1].score : null;
+}
+
+/** Latest numeric score of the season, else null. */
+function latestScore(season: SeasonScores): number | null {
+  const numeric = season.scores.filter(
+    (s): s is typeof s & { score: number } => typeof s.score === 'number',
+  );
+  return numeric.length ? numeric[numeric.length - 1].score : null;
+}
+
+/** Finals score when finished, otherwise the latest in-season score. */
+export function finalsOrLatestScore(season: SeasonScores): number | null {
+  return finalsScore(season) ?? latestScore(season);
+}
+
+function finalsRank(
+  seasons: SeasonScores[],
+  season: SeasonScores,
+): number | null {
+  const mine = finalsScore(season);
+  if (mine === null) return null;
+  const ahead = seasons.filter((s) => {
+    if (s.year === season.year) return false;
+    const other = finalsScore(s);
+    return other !== null && other >= mine;
+  }).length;
+  return ahead + 1;
+}
+
+export function tourSummary(
+  seasons: SeasonScores[],
+  season: SeasonScores,
+): TourSummary {
+  const log = buildTourLog(seasons, season);
+  const numeric = log.filter(
+    (r): r is TourLogRow & { score: number } => r.score !== null,
+  );
+  if (numeric.length === 0) {
+    return {
+      seasonHigh: null,
+      climb: null,
+      topFiveDays: 0,
+      allTimeBestDays: 0,
+      finalsScore: null,
+      finalsRank: null,
+    };
+  }
+  return {
+    seasonHigh: Math.max(...numeric.map((r) => r.score)),
+    climb: numeric[numeric.length - 1].score - numeric[0].score,
+    topFiveDays: numeric.filter((r) => r.rankNow !== null && r.rankNow <= 5)
+      .length,
+    allTimeBestDays: numeric.filter((r) => r.rankNow === 1).length,
+    finalsScore: finalsScore(season),
+    finalsRank: finalsRank(seasons, season),
+  };
+}
+
+/** Human label for a DCI placement, or null when unplaced. */
+export function placementLabel(placement: number | undefined): string | null {
+  if (placement == null) return null;
+  if (placement === 1) return 'DCI World Champion';
+  if (placement === 2) return 'DCI Silver Medalist';
+  if (placement === 3) return 'DCI Bronze Medalist';
+  if (placement <= 6)
+    return `Top 6 · ${placement}${ordinalSuffix(placement)} place`;
+  if (placement <= 12)
+    return `Top 12 · ${placement}${ordinalSuffix(placement)} place`;
+  return `${placement}${ordinalSuffix(placement)} place`;
 }

--- a/src/lib/utils/tour.ts
+++ b/src/lib/utils/tour.ts
@@ -65,7 +65,7 @@ function rankAmong(
 ): number {
   const ahead = seasons.filter((s) => {
     const peer = scoreAsOfDay(s, day);
-    return peer !== null && peer >= score;
+    return peer !== null && peer > score;
   }).length;
   return ahead + 1;
 }

--- a/src/lib/utils/tour.ts
+++ b/src/lib/utils/tour.ts
@@ -50,3 +50,66 @@ export function isInProgress(season: SeasonScores): boolean {
   const hasNumeric = season.scores.some((s) => typeof s.score === 'number');
   return hasScheduled && hasNumeric;
 }
+
+export interface TourLogRow extends TourStop {
+  /** Rank among seasons *before* this one at this day. `null` for null-score rows. */
+  rankThen: number | null;
+  /** Rank among *all other* seasons at this day. `null` for null-score rows. */
+  rankNow: number | null;
+}
+
+function rankAmong(
+  seasons: SeasonScores[],
+  day: number,
+  score: number,
+): number {
+  const ahead = seasons.filter((s) => {
+    const peer = scoreAsOfDay(s, day);
+    return peer !== null && peer >= score;
+  }).length;
+  return ahead + 1;
+}
+
+/** Rank of `score` at `day` among seasons that came before `year`. */
+export function rankThen(
+  seasons: SeasonScores[],
+  year: string,
+  day: number,
+  score: number,
+): number {
+  const peers = seasons.filter((s) => Number(s.year) < Number(year));
+  return rankAmong(peers, day, score);
+}
+
+/** Rank of `score` at `day` among all seasons except `excludeYear`. */
+export function rankNow(
+  seasons: SeasonScores[],
+  day: number,
+  score: number,
+  excludeYear: string,
+): number {
+  const peers = seasons.filter((s) => s.year !== excludeYear);
+  return rankAmong(peers, day, score);
+}
+
+/** Per-show tour log for `season`, enriched with rank-then / rank-now. */
+export function buildTourLog(
+  seasons: SeasonScores[],
+  season: SeasonScores,
+): TourLogRow[] {
+  return buildTour(season).map((stop) => {
+    if (stop.score === null) {
+      return { ...stop, rankThen: null, rankNow: null };
+    }
+    return {
+      ...stop,
+      rankThen: rankThen(
+        seasons,
+        season.year,
+        stop.daysBeforeFinals,
+        stop.score,
+      ),
+      rankNow: rankNow(seasons, stop.daysBeforeFinals, stop.score, season.year),
+    };
+  });
+}

--- a/src/lib/utils/tour.ts
+++ b/src/lib/utils/tour.ts
@@ -159,6 +159,9 @@ function finalsRank(
   const ahead = seasons.filter((s) => {
     if (s.year === season.year) return false;
     const other = finalsScore(s);
+    // `>=` (not `>`): a season tied at the best-ever finals score does not get
+    // sole credit for #1 — unlike the per-day rank-then/rank-now helpers, which
+    // share a rank on ties. Intentional asymmetry for the all-time finals stat.
     return other !== null && other >= mine;
   }).length;
   return ahead + 1;

--- a/src/routes/tour/+page.svelte
+++ b/src/routes/tour/+page.svelte
@@ -59,7 +59,10 @@
         <span
           class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-2.5 py-1 text-xs font-semibold text-gray-700"
         >
-          {#if season.placement === 1}🥇{:else if season.placement === 2}🥈{:else if season.placement === 3}🥉{/if}
+          {#if season.placement === 1}<span aria-hidden="true">🥇</span
+            >{:else if season.placement === 2}<span aria-hidden="true">🥈</span
+            >{:else if season.placement === 3}<span aria-hidden="true">🥉</span
+            >{/if}
           {placement}
         </span>
       {/if}

--- a/src/routes/tour/+page.svelte
+++ b/src/routes/tour/+page.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { page } from '$app/state';
+  import Card from '$components/shared/Card.svelte';
+  import PageContent from '$components/shared/PageContent.svelte';
+  import SeasonPicker from '$components/tour/SeasonPicker.svelte';
+  import TourStats from '$components/tour/TourStats.svelte';
+  import TourLog from '$components/tour/TourLog.svelte';
+  import { POPULATED_SEASONS } from '$data';
+  import {
+    buildTourLog,
+    tourSummary,
+    isInProgress,
+    placementLabel,
+  } from '$lib/utils/tour';
+  import { setParam } from '$lib/utils/url-state';
+
+  const defaultSeason = POPULATED_SEASONS[POPULATED_SEASONS.length - 1];
+  const yearParam = $derived(
+    browser ? page.url.searchParams.get('year') : null,
+  );
+  const season = $derived(
+    POPULATED_SEASONS.find((s) => s.year === yearParam) ?? defaultSeason,
+  );
+
+  const rows = $derived(buildTourLog(POPULATED_SEASONS, season));
+  const summary = $derived(tourSummary(POPULATED_SEASONS, season));
+  const inProgress = $derived(isInProgress(season));
+  const placement = $derived(placementLabel(season.placement));
+
+  const subtitle = $derived.by(() => {
+    const count = `${rows.length} ${rows.length === 1 ? 'show' : 'shows'}`;
+    if (inProgress) {
+      return summary.seasonHigh !== null
+        ? `${count} so far · high ${summary.seasonHigh.toFixed(3)}`
+        : `${count} so far`;
+    }
+    if (summary.finalsScore !== null && summary.finalsRank !== null) {
+      return `${count} · Final score ${summary.finalsScore.toFixed(3)} · #${summary.finalsRank} all-time finals score`;
+    }
+    return summary.seasonHigh !== null
+      ? `${count} · season high ${summary.seasonHigh.toFixed(3)}`
+      : count;
+  });
+
+  function onYearChange(year: string) {
+    void setParam('year', year === defaultSeason.year ? null : year);
+  }
+</script>
+
+<svelte:head>
+  <title>{season.year} Tour | Bluecoats Scores</title>
+</svelte:head>
+
+<header class="mx-auto flex max-w-300 flex-col gap-2 px-4 pt-4 sm:pt-8 md:px-6">
+  {#if placement || inProgress}
+    <div class="flex flex-wrap items-center gap-2">
+      {#if placement}
+        <span
+          class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-2.5 py-1 text-xs font-semibold text-gray-700"
+        >
+          {#if season.placement === 1}🥇{:else if season.placement === 2}🥈{:else if season.placement === 3}🥉{/if}
+          {placement}
+        </span>
+      {/if}
+      {#if inProgress}
+        <span
+          class="inline-flex items-center gap-1.5 rounded-full bg-brand-100 px-2.5 py-1 text-xs font-semibold text-brand-600"
+        >
+          <span class="size-1.5 rounded-full bg-brand-600"></span>Season in
+          progress
+        </span>
+      {/if}
+    </div>
+  {/if}
+  <div>
+    <h1 class="text-3xl font-bold tracking-tight text-gray-900">
+      {season.year} · {season.show ?? 'Untitled'}
+    </h1>
+    <p class="mt-1 text-sm text-gray-500">{subtitle}</p>
+  </div>
+</header>
+
+<PageContent>
+  <div class="grid grid-cols-1 gap-4">
+    <Card subtle>
+      <SeasonPicker
+        seasons={POPULATED_SEASONS}
+        year={season.year}
+        onChange={onYearChange}
+      />
+    </Card>
+    <TourStats {summary} {inProgress} />
+    <Card disablePadding>
+      <div
+        class="flex items-baseline justify-between border-b border-gray-200 px-4 py-4 sm:px-6"
+      >
+        <div>
+          <div class="text-sm font-semibold text-gray-900">
+            Tour log · every show
+          </div>
+          <div class="text-xs text-gray-500">
+            Rank then = at the time · Rank now = today
+          </div>
+        </div>
+      </div>
+      <TourLog {rows} />
+      <div
+        class="border-t border-gray-200 bg-gray-50 px-4 py-4 text-xs leading-relaxed text-gray-500 sm:px-6"
+      >
+        <span class="font-semibold text-gray-700">How to read this:</span>
+        "Rank then" reflects only the seasons completed before this one. "Rank now"
+        includes every Bluecoats season since. The Δ column shows whether history
+        has caught up.
+      </div>
+    </Card>
+  </div>
+</PageContent>

--- a/tests/e2e/tour.test.ts
+++ b/tests/e2e/tour.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+test('renders the default season tour log', async ({ page }) => {
+  await page.goto('/tour');
+  // Default season is the most recent populated one; its heading is "<year> · <show>".
+  await expect(page.getByRole('heading', { name: /·/ })).toBeVisible();
+  await expect(page.getByText('Tour log · every show')).toBeVisible();
+  // The tour log has at least one show row.
+  await expect(page.locator('tbody tr').first()).toBeVisible();
+});
+
+test('year param drives the season and the picker updates the URL', async ({
+  page,
+}) => {
+  await page.goto('/tour?year=2024');
+  await expect(page).toHaveURL(/[?&]year=2024\b/);
+  await expect(page.getByRole('heading', { name: /^2024 ·/ })).toBeVisible();
+  // Jump to 2023 via the scrubber tick (aria-label "2023 season").
+  await page.getByRole('button', { name: '2023 season' }).click();
+  await expect(page).toHaveURL(/[?&]year=2023\b/);
+  await expect(page.getByRole('heading', { name: /^2023 ·/ })).toBeVisible();
+});

--- a/tests/e2e/tour.test.ts
+++ b/tests/e2e/tour.test.ts
@@ -20,3 +20,14 @@ test('year param drives the season and the picker updates the URL', async ({
   await expect(page).toHaveURL(/[?&]year=2023\b/);
   await expect(page.getByRole('heading', { name: /^2023 ·/ })).toBeVisible();
 });
+
+test('renders a season with same-date shows (doubleheader) without crashing', async ({
+  page,
+}) => {
+  // 1986 has prelims+finals on the same date — a duplicate-key hazard that
+  // previously blanked the page. The heading and table rows must render.
+  await page.goto('/tour?year=1986');
+  await expect(page.getByRole('heading', { name: /^1986 ·/ })).toBeVisible();
+  const rows = page.locator('tbody tr');
+  expect(await rows.count()).toBeGreaterThan(0);
+});

--- a/tests/unit/tour.test.ts
+++ b/tests/unit/tour.test.ts
@@ -56,6 +56,10 @@ describe('scoreAsOfDay', () => {
   it('returns null when no scored show is that early', () => {
     expect(scoreAsOfDay(S2024, 60)).toBeNull();
   });
+
+  it('skips null-score stops when looking back', () => {
+    expect(scoreAsOfDay(S2024, 35)).toBe(74);
+  });
 });
 
 describe('isInProgress', () => {

--- a/tests/unit/tour.test.ts
+++ b/tests/unit/tour.test.ts
@@ -102,6 +102,17 @@ const S2023: SeasonScores = {
 
 const ALL = [S2022, S2023, S2024, S2025_INPROGRESS];
 
+// A season with two scored shows on the SAME date (prelims + finals doubleheader).
+const S_DOUBLEHEADER: SeasonScores = {
+  year: '1986',
+  endDate: '1986-08-16',
+  scores: [
+    { date: '1986-07-01', location: 'Whitewater, WI', score: 70 },
+    { date: '1986-08-16', location: 'Madison, WI', name: 'Prelims', score: 80 },
+    { date: '1986-08-16', location: 'Madison, WI', name: 'Finals', score: 81 },
+  ],
+};
+
 describe('rankThen / rankNow', () => {
   it('rankThen counts only seasons before the given year', () => {
     // At 21 days out, 2024 scored 91. Among prior seasons (2022→85, 2023→88)
@@ -193,5 +204,21 @@ describe('placementLabel', () => {
     expect(placementLabel(10)).toBe('Top 12 · 10th place');
     expect(placementLabel(15)).toBe('15th place');
     expect(placementLabel(undefined)).toBeNull();
+  });
+});
+
+describe('same-date shows', () => {
+  it('keeps both shows on a shared date as distinct rows', () => {
+    const tour = buildTour(S_DOUBLEHEADER);
+    expect(tour).toHaveLength(3);
+    // Both day-0 shows are present and retain their distinct names/scores.
+    const finalsDay = tour.filter((s) => s.daysBeforeFinals === 0);
+    expect(finalsDay.map((s) => s.score)).toEqual([80, 81]);
+    expect(finalsDay.map((s) => s.name)).toEqual(['Prelims', 'Finals']);
+  });
+
+  it('builds a tour log with the same row count (no collapsing of shared dates)', () => {
+    const log = buildTourLog([...ALL, S_DOUBLEHEADER], S_DOUBLEHEADER);
+    expect(log).toHaveLength(3);
   });
 });

--- a/tests/unit/tour.test.ts
+++ b/tests/unit/tour.test.ts
@@ -6,6 +6,9 @@ import {
   rankThen,
   rankNow,
   buildTourLog,
+  tourSummary,
+  finalsOrLatestScore,
+  placementLabel,
 } from '../../src/lib/utils/tour';
 import type { SeasonScores } from '../../src/lib/data/base';
 
@@ -138,5 +141,44 @@ describe('buildTourLog', () => {
     const exhibition = log.find((r) => r.score === null)!;
     expect(exhibition.rankThen).toBeNull();
     expect(exhibition.rankNow).toBeNull();
+  });
+});
+
+describe('tourSummary', () => {
+  it('summarizes a completed season', () => {
+    const s = tourSummary(ALL, S2024);
+    expect(s.seasonHigh).toBe(95);
+    expect(s.climb).toBe(21); // 95 - 74 (null row ignored)
+    expect(s.finalsScore).toBe(95);
+    expect(s.finalsRank).toBe(1); // no other season's finals reached 95
+  });
+
+  it('reports no finals score/rank for an in-progress season', () => {
+    const s = tourSummary(ALL, S2025_INPROGRESS);
+    expect(s.finalsScore).toBeNull();
+    expect(s.finalsRank).toBeNull();
+    expect(s.seasonHigh).toBe(92);
+  });
+});
+
+describe('finalsOrLatestScore', () => {
+  it('uses the finals score when the season finished', () => {
+    expect(finalsOrLatestScore(S2024)).toBe(95);
+  });
+
+  it('falls back to the latest score mid-season', () => {
+    expect(finalsOrLatestScore(S2025_INPROGRESS)).toBe(92);
+  });
+});
+
+describe('placementLabel', () => {
+  it('labels medals, top tiers, and plain places', () => {
+    expect(placementLabel(1)).toBe('DCI World Champion');
+    expect(placementLabel(2)).toBe('DCI Silver Medalist');
+    expect(placementLabel(3)).toBe('DCI Bronze Medalist');
+    expect(placementLabel(5)).toBe('Top 6 · 5th place');
+    expect(placementLabel(10)).toBe('Top 12 · 10th place');
+    expect(placementLabel(15)).toBe('15th place');
+    expect(placementLabel(undefined)).toBeNull();
   });
 });

--- a/tests/unit/tour.test.ts
+++ b/tests/unit/tour.test.ts
@@ -151,6 +151,19 @@ describe('tourSummary', () => {
     expect(s.climb).toBe(21); // 95 - 74 (null row ignored)
     expect(s.finalsScore).toBe(95);
     expect(s.finalsRank).toBe(1); // no other season's finals reached 95
+    expect(s.topFiveDays).toBe(3); // all three numeric stops (74,91,95) rank top-5 all-time
+    expect(s.allTimeBestDays).toBe(2); // day-49 (74) and day-0 (95) are #1 all-time; day-21 (91) is #2 because 2025 reached 92 by then
+  });
+
+  it('does not award sole rank-1 when a finals score is tied', () => {
+    const tie2030: SeasonScores = {
+      year: '2030',
+      endDate: '2030-08-10',
+      scores: [{ date: '2030-08-10', location: 'Indianapolis, IN', score: 95 }],
+    };
+    // 2030 ties S2024's 95 at finals → finalsRank 2 (>= semantics), not 1.
+    const s = tourSummary([...ALL, tie2030], tie2030);
+    expect(s.finalsRank).toBe(2);
   });
 
   it('reports no finals score/rank for an in-progress season', () => {

--- a/tests/unit/tour.test.ts
+++ b/tests/unit/tour.test.ts
@@ -110,6 +110,23 @@ describe('rankThen / rankNow', () => {
     // 2025 reaches 92 by 22 days out, which beats 91 → 2024 drops to #2 now.
     expect(rankNow(ALL, 21, 91, '2024')).toBe(2);
   });
+
+  it('treats an exact tie as the same rank, not behind', () => {
+    const tieA: SeasonScores = {
+      year: '2010',
+      endDate: '2010-08-14',
+      scores: [{ date: '2010-08-14', location: 'Indianapolis, IN', score: 90 }],
+    };
+    const tieB: SeasonScores = {
+      year: '2011',
+      endDate: '2011-08-13',
+      scores: [{ date: '2011-08-13', location: 'Indianapolis, IN', score: 90 }],
+    };
+    // 2011's 90 ties 2010's 90 at finals — it shares #1, not pushed to #2.
+    expect(rankNow([tieA, tieB], 0, 90, '2011')).toBe(1);
+    // And "at the time", only 2010 existed and tied — still #1.
+    expect(rankThen([tieA, tieB], '2011', 0, 90)).toBe(1);
+  });
 });
 
 describe('buildTourLog', () => {

--- a/tests/unit/tour.test.ts
+++ b/tests/unit/tour.test.ts
@@ -3,6 +3,9 @@ import {
   buildTour,
   scoreAsOfDay,
   isInProgress,
+  rankThen,
+  rankNow,
+  buildTourLog,
 } from '../../src/lib/utils/tour';
 import type { SeasonScores } from '../../src/lib/data/base';
 
@@ -69,5 +72,54 @@ describe('isInProgress', () => {
 
   it('is false for a fully completed season', () => {
     expect(isInProgress(S2024)).toBe(false);
+  });
+});
+
+const S2022: SeasonScores = {
+  year: '2022',
+  endDate: '2022-08-13',
+  placement: 3,
+  scores: [
+    { date: '2022-06-25', location: 'Akron, OH', score: 70 },
+    { date: '2022-07-20', location: 'San Antonio, TX', score: 85 },
+    { date: '2022-08-13', location: 'Indianapolis, IN', score: 90 },
+  ],
+};
+
+const S2023: SeasonScores = {
+  year: '2023',
+  endDate: '2023-08-12',
+  placement: 2,
+  scores: [
+    { date: '2023-06-24', location: 'Akron, OH', score: 72 },
+    { date: '2023-07-19', location: 'San Antonio, TX', score: 88 },
+    { date: '2023-08-12', location: 'Indianapolis, IN', score: 93 },
+  ],
+};
+
+const ALL = [S2022, S2023, S2024, S2025_INPROGRESS];
+
+describe('rankThen / rankNow', () => {
+  it('rankThen counts only seasons before the given year', () => {
+    // At 21 days out, 2024 scored 91. Among prior seasons (2022→85, 2023→88)
+    // none reached 91, so it was #1 at the time.
+    expect(rankThen(ALL, '2024', 21, 91)).toBe(1);
+  });
+
+  it('rankNow counts all other seasons, including later ones', () => {
+    // 2025 reaches 92 by 22 days out, which beats 91 → 2024 drops to #2 now.
+    expect(rankNow(ALL, 21, 91, '2024')).toBe(2);
+  });
+});
+
+describe('buildTourLog', () => {
+  it('attaches ranks to numeric rows and leaves null rows unranked', () => {
+    const log = buildTourLog(ALL, S2024);
+    const row21 = log.find((r) => r.daysBeforeFinals === 21)!;
+    expect(row21.rankThen).toBe(1);
+    expect(row21.rankNow).toBe(2);
+    const exhibition = log.find((r) => r.score === null)!;
+    expect(exhibition.rankThen).toBeNull();
+    expect(exhibition.rankNow).toBeNull();
   });
 });

--- a/tests/unit/tour.test.ts
+++ b/tests/unit/tour.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildTour,
+  scoreAsOfDay,
+  isInProgress,
+} from '../../src/lib/utils/tour';
+import type { SeasonScores } from '../../src/lib/data/base';
+
+// Completed championship season. Includes one exhibition (null score) stop.
+const S2024: SeasonScores = {
+  year: '2024',
+  endDate: '2024-08-10',
+  placement: 1,
+  show: 'Test Show',
+  scores: [
+    { date: '2024-06-22', location: 'Akron, OH', name: 'Opener', score: 74 },
+    { date: '2024-07-06', location: 'Whitewater, WI', score: null }, // exhibition
+    { date: '2024-07-20', location: 'San Antonio, TX', score: 91 },
+    { date: '2024-08-10', location: 'Indianapolis, IN', score: 95 },
+  ],
+};
+
+// Mid-season: two competed shows + a still-scheduled finals (undefined score).
+const S2025_INPROGRESS: SeasonScores = {
+  year: '2025',
+  endDate: '2025-08-09',
+  scores: [
+    { date: '2025-06-23', location: 'Akron, OH', score: 75 },
+    { date: '2025-07-18', location: 'San Antonio, TX', score: 92 },
+    { date: '2025-08-09', location: 'Indianapolis, IN' }, // not competed yet
+  ],
+};
+
+describe('buildTour', () => {
+  it('includes numeric and null scores, excludes not-yet-competed', () => {
+    const tour = buildTour(S2024);
+    expect(tour.map((s) => s.daysBeforeFinals)).toEqual([49, 35, 21, 0]);
+    expect(tour.map((s) => s.score)).toEqual([74, null, 91, 95]);
+    expect(tour[0].name).toBe('Opener');
+  });
+
+  it('drops undefined-score (scheduled) stops', () => {
+    const tour = buildTour(S2025_INPROGRESS);
+    expect(tour.map((s) => s.daysBeforeFinals)).toEqual([47, 22]);
+    expect(tour.map((s) => s.score)).toEqual([75, 92]);
+  });
+});
+
+describe('scoreAsOfDay', () => {
+  it('returns the latest numeric score at or before the given day', () => {
+    expect(scoreAsOfDay(S2024, 21)).toBe(91);
+    expect(scoreAsOfDay(S2024, 22)).toBe(74);
+    expect(scoreAsOfDay(S2024, 0)).toBe(95);
+  });
+
+  it('returns null when no scored show is that early', () => {
+    expect(scoreAsOfDay(S2024, 60)).toBeNull();
+  });
+});
+
+describe('isInProgress', () => {
+  it('is true when a season has both competed and still-scheduled shows', () => {
+    expect(isInProgress(S2025_INPROGRESS)).toBe(true);
+  });
+
+  it('is false for a fully completed season', () => {
+    expect(isInProgress(S2024)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new **Tour** page — a per-season detail view of one Bluecoats season's tour, adapted from the "Bluecoats Refresh" design mock (page 4) but built in the **current app's visual language** (existing `Card`/`PageContent` components and Tailwind style) so it sits alongside the existing three pages.

For a selected season it shows:
- A **tour log** of every show with score, **rank then** (rank among Bluecoats seasons that existed before that year), **rank now** (rank among all other seasons today), and a **Δ** showing whether history has caught up.
- **Summary stat tiles** (season high, climb across tour, top-5 days, all-time #1 days).
- A **season picker** (prev/next, a select, and a year scrubber), with the season in the `?year=` URL param.

The page is prerendered; the default season is the most recent populated one, and `?year=` is read client-side (`browser`-gated) — same pattern as Daily ranking. A new **Tour** entry was added to the desktop nav and mobile tab bar.

### Notable details
- New pure, unit-tested util `src/lib/utils/tour.ts` reusing the existing Luxon/`FINALS_ZONE` day-math from `daily-ranking.ts`.
- Exhibition/`null`-score stops are shown in the log (marked "no score") but excluded from ranks; not-yet-competed (`undefined`) stops are filtered out.
- Rank ties use strictly-greater to match `daily-ranking`'s competition-ranking convention.
- Rows are keyed by index to handle seasons with multiple shows on the same date (prelims+finals / doubleheaders) — caught by the integration review and covered by a regression test.

## Test Plan
- [x] `pnpm lint` clean (ESLint, Stylelint, svelte-check, Prettier)
- [x] `pnpm test:unit` — 87 unit tests pass (incl. new `tour.ts` suite)
- [x] `pnpm test:e2e` — 9 Playwright tests pass (incl. default season, `?year=` navigation, and a same-date/doubleheader season)
- [x] `pnpm build` — `/tour` prerenders cleanly
- [x] Manual: open `/tour`, switch seasons via picker/scrubber/select, verify URL updates and a championship + a non-finalist + a same-date season all render

🤖 Generated with [Claude Code](https://claude.com/claude-code)