### PR TITLE
chore: add Dependabot cooldown to match pnpm minimumReleaseAge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 15
+    # Wait for releases to age past pnpm's ~24h minimumReleaseAge supply-chain
+    # policy before opening PRs, so fresh bumps don't fail CI on install.
+    cooldown:
+      default-days: 2
     groups:
       eslint:
         applies-to: version-updates


### PR DESCRIPTION
## What

Adds a Dependabot `cooldown` of **2 days** to the npm ecosystem in `.github/dependabot.yml`.

```yaml
cooldown:
  default-days: 2
```

## Why

CI runs `pnpm install --frozen-lockfile`, which enforces a pnpm **`minimumReleaseAge`** supply-chain policy with a ~24h cutoff. Dependabot opens PRs within hours of a release, so freshly-published bumps fail the **Install Dependencies** step on age alone (`ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`) — spurious failures, not real breakage. This recently affected #341 (eslint), #345 (prettier), and #347 (tailwindcss) in the same review batch.

`cooldown` makes Dependabot wait for a release to age before opening the PR, so by the time CI runs the version is already past the 24h gate.

## Why 2 days, not 1

The policy is "≥24h", but Dependabot counts in whole days and runs on a daily schedule, so `default-days: 2` clears 24h with zero boundary risk. Drop to `1` if you'd prefer the literal match / minimal delay.

## Scope

- Applies only to the **npm** ecosystem — the GitHub Actions ecosystem doesn't install via `pnpm`, so it isn't subject to the policy and is left unchanged.
- Forward-looking only: it won't unblock the already-open #345/#347 (those just need to age out naturally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)