### PR TITLE
Add 2026 show name and log Opening Night exhibition

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -3,11 +3,13 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2026: SeasonScores = {
   year: '2026',
   endDate: '2026-08-08',
+  show: 'Gravity & Grace',
   scores: [
     {
       date: '2026-06-27',
       location: 'Alliance, OH',
       name: 'Bluecoats Opening Night Community Celebration',
+      score: null,
     },
     { date: '2026-07-02', location: 'Camarillo, CA', name: 'MidCal Showcase' },
     {


### PR DESCRIPTION
## Summary

Prep work ahead of the 2026 season logging real scores:

- **Show name** — the 2026 show now has a title, **"Gravity & Grace"** (added `show:` to `SEASON_2026`).
- **Opening Night** — the Bluecoats Opening Night Community Celebration (2026-06-27, Alliance OH) was an exhibition with no published score, so it's logged as `score: null`.

## Why this is safe

A `null` score does **not** make 2026 appear as a populated season. `POPULATED_SEASONS` (`src/lib/data/index.ts`) filters on `typeof score.score === 'number'`, and `typeof null === 'object'`, so the entry is excluded. Every score-rendering surface (chart, season select, daily rankings, Logo year range, tour page) reads from `POPULATED_SEASONS`, so 2026 stays invisible until its first real number lands.

## Verification

- `pnpm lint` — all green (types, js, css, format, knip)
- `pnpm test:unit` — 87/87 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)