### PR TITLE
Log DCI Capital Classic score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -16,6 +16,7 @@ export const SEASON_2026: SeasonScores = {
       date: '2026-07-03',
       location: 'Sacramento, CA',
       name: 'DCI Capital Classic',
+      score: 82.2,
     },
     { date: '2026-07-05', location: 'Stanford, CA', name: 'DCI West' },
     {

--- a/tests/e2e/daily-ranking.test.ts
+++ b/tests/e2e/daily-ranking.test.ts
@@ -10,9 +10,9 @@ test('renders rankings table and slider', async ({ page }) => {
     page.getByRole('heading', { name: 'Daily ranking' }),
   ).toBeVisible();
   await expect(page.getByLabel('Days before Finals')).toBeVisible();
-  // 45 ranked seasons means 45 data rows in the tbody
+  // 46 ranked seasons means 46 data rows in the tbody
   const rows = page.locator('tbody tr');
-  await expect(rows).toHaveCount(45);
+  await expect(rows).toHaveCount(46);
 });
 
 test('day param drives the leaderboard and chips update the URL', async ({


### PR DESCRIPTION
Logs the Bluecoats' score of **82.2** at **DCI Capital Classic** (Sacramento, CA — 2026-07-03) by filling in the `score` on the existing scheduled entry in `src/lib/data/seasons/2026.ts`.

- `pnpm lint` ✅
- `pnpm test:unit` ✅ (87 passed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYfuwrv9GXkFW5zmChiLFa)_