### PR TITLE
Log MidCal Showcase as non-scored for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -11,7 +11,12 @@ export const SEASON_2026: SeasonScores = {
       name: 'Bluecoats Opening Night Community Celebration',
       score: null,
     },
-    { date: '2026-07-02', location: 'Camarillo, CA', name: 'MidCal Showcase' },
+    {
+      date: '2026-07-02',
+      location: 'Camarillo, CA',
+      name: 'MidCal Showcase',
+      score: null,
+    },
     {
       date: '2026-07-03',
       location: 'Sacramento, CA',


### PR DESCRIPTION
Records **MidCal Showcase** (Camarillo, CA — 2026-07-02) as a non-scored exhibition (`score: null`) on the existing scheduled entry in `src/lib/data/seasons/2026.ts`.

`null` marks that the event happened but produced no comparable score, so it's filtered out of the chart, season select, and daily rankings — the 2026 season's populated status and row counts are unaffected.

- `pnpm lint` ✅
- `pnpm test:unit` ✅ (87 passed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYfuwrv9GXkFW5zmChiLFa)_