### PR TITLE
Highlight the current season row on Daily Ranking

### DIFF
--- a/src/lib/components/daily-ranking/Table.svelte
+++ b/src/lib/components/daily-ranking/Table.svelte
@@ -2,7 +2,10 @@
   import type { DailyRankingItem } from '$lib/utils/daily-ranking';
   import { ordinalSuffix } from '$lib/utils/ordinal';
 
-  let { rankings }: { rankings: DailyRankingItem[] } = $props();
+  let {
+    rankings,
+    currentYear,
+  }: { rankings: DailyRankingItem[]; currentYear?: string } = $props();
 
   const range = $derived.by(() => {
     if (rankings.length === 0) return { max: 0, min: 0 };
@@ -72,8 +75,17 @@
     {#each rankings as ranking (ranking.year)}
       {@const medal =
         ranking.placement && ranking.placement <= 3 ? ranking.placement : null}
-      <tr class="hover:bg-gray-50">
-        <td class="py-3 pr-3 pl-4 align-middle sm:pl-6">
+      {@const isCurrent = ranking.year === currentYear}
+      <tr
+        class={isCurrent
+          ? 'bg-gradient-to-r from-brand-600/8 to-brand-600/2'
+          : 'hover:bg-gray-50'}
+      >
+        <td
+          class="py-3 pr-3 pl-4 align-middle sm:pl-6 {isCurrent
+            ? 'shadow-[inset_0.1875rem_0_0_0_var(--color-brand-600)]'
+            : ''}"
+        >
           <span
             class="inline-flex h-6 min-w-7 items-center justify-center rounded-md px-1.5 text-xs font-semibold tabular-nums {rankClass(
               ranking.rank,
@@ -86,11 +98,17 @@
         <td
           class="w-full max-w-0 px-3 py-3 align-middle sm:w-auto sm:max-w-none sm:whitespace-nowrap"
         >
-          <div class="text-sm font-semibold text-gray-900 tabular-nums">
+          <div
+            class="text-sm font-semibold tabular-nums {isCurrent
+              ? 'text-navy-800'
+              : 'text-gray-900'}"
+          >
             {ranking.year}{#if medal}<span
                 class="ml-1.5"
                 role="img"
                 aria-label={MEDAL_LABEL[medal]}>{MEDAL_EMOJI[medal]}</span
+              >{/if}{#if isCurrent}<span class="sr-only">
+                (current season)</span
               >{/if}
           </div>
           {#if ranking.show}
@@ -112,7 +130,11 @@
         <td
           class="px-3 py-3 pr-4 text-right align-middle whitespace-nowrap tabular-nums sm:pr-3"
         >
-          <div class="text-sm font-semibold text-gray-900">
+          <div
+            class="text-sm font-semibold {isCurrent
+              ? 'text-brand-600'
+              : 'text-gray-900'}"
+          >
             {ranking.score.toFixed(3)}
           </div>
           {#if ranking.daysOld}
@@ -128,9 +150,11 @@
             role="presentation"
           >
             <span
-              class="absolute top-0 bottom-0 left-0 rounded-full {medal
-                ? MEDAL_BAR_CLASS[medal]
-                : 'bg-brand-600'}"
+              class="absolute top-0 bottom-0 left-0 rounded-full {isCurrent
+                ? 'bg-brand-600 ring-[1.5px] ring-brand-600/25'
+                : medal
+                  ? MEDAL_BAR_CLASS[medal]
+                  : 'bg-brand-600'}"
               style="width: {barWidth(ranking.score)}%"
             ></span>
           </div>

--- a/src/lib/utils/daily-ranking.ts
+++ b/src/lib/utils/daily-ranking.ts
@@ -79,6 +79,13 @@ export function currentDayUntilFinals(
   return days > maxDay ? 0 : days;
 }
 
+export function currentSeasonYear(seasons: SeasonScores[]): string | undefined {
+  if (seasons.length === 0) return undefined;
+  return seasons.reduce((newest, season) =>
+    Number(season.year) > Number(newest.year) ? season : newest,
+  ).year;
+}
+
 export function maxDayBeforeFinals(seasons: SeasonScores[]): number {
   const seasonDays = seasons
     .map((season) => {

--- a/src/routes/daily-ranking/+page.svelte
+++ b/src/routes/daily-ranking/+page.svelte
@@ -10,6 +10,7 @@
   import {
     buildDailyRankings,
     currentDayUntilFinals,
+    currentSeasonYear,
     maxDayBeforeFinals,
   } from '$lib/utils/daily-ranking';
   import { setParam } from '$lib/utils/url-state';
@@ -24,6 +25,7 @@
     return raw >= 0 ? raw : 0;
   });
   const rankings = $derived(buildDailyRankings(POPULATED_SEASONS, selectedDay));
+  const currentYear = $derived(currentSeasonYear(POPULATED_SEASONS));
 
   function onDayChange(day: number) {
     void setParam('day', day === currentDay ? null : String(day));
@@ -62,7 +64,7 @@
           </div>
         </div>
       </div>
-      <Table {rankings} />
+      <Table {rankings} {currentYear} />
     </Card>
   </div>
 </PageContent>

--- a/tests/unit/daily-ranking.test.ts
+++ b/tests/unit/daily-ranking.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   buildDailyRankings,
   currentDayUntilFinals,
+  currentSeasonYear,
   maxDayBeforeFinals,
 } from '../../src/lib/utils/daily-ranking';
 import type { SeasonScores } from '../../src/lib/data/base';
@@ -225,6 +226,39 @@ describe('currentDayUntilFinals', () => {
     // No populated seasons → maxDay is 0; any future finals exceeds the bound.
     vi.setSystemTime(new Date('2025-07-10T12:00:00Z'));
     expect(currentDayUntilFinals([SEASON_2025], 0)).toBe(0);
+  });
+});
+
+describe('currentSeasonYear', () => {
+  it('returns undefined for an empty array', () => {
+    expect(currentSeasonYear([])).toBeUndefined();
+  });
+
+  it('returns the highest year as a string', () => {
+    expect(currentSeasonYear([SEASON_2023, SEASON_2024, SEASON_2025])).toBe(
+      '2025',
+    );
+  });
+
+  it('returns the max for unordered input', () => {
+    expect(currentSeasonYear([SEASON_2024, SEASON_2025, SEASON_2023])).toBe(
+      '2025',
+    );
+  });
+
+  it('compares years numerically, not lexically', () => {
+    // Lexical comparison would put '999' after '2010' since '9' > '2'.
+    const seasonShort: SeasonScores = {
+      year: '999',
+      endDate: '0999-08-12',
+      scores: [],
+    };
+    const seasonLong: SeasonScores = {
+      year: '2010',
+      endDate: '2010-08-12',
+      scores: [],
+    };
+    expect(currentSeasonYear([seasonShort, seasonLong])).toBe('2010');
   });
 });
 


### PR DESCRIPTION
## What

Adds a row highlight to the **Daily ranking** page marking the **current season** — defined as the newest (highest-year) season present in `POPULATED_SEASONS`. Today that is **2026** (Gravity & Grace), which now has its first scored result. The determination is dynamic (no hardcoded year); the highlight automatically follows the newest scored season and only appears when that season's row is present at the selected day.

The styling reproduces the "current season" treatment from the imported *Bluecoats Reimagined* mobile design mockup.

## Changes

- **`currentSeasonYear(seasons)`** helper in `src/lib/utils/daily-ranking.ts` — returns the highest-year season's `year` (string), compared numerically. Covered by new unit tests (numeric-vs-lexical, unordered input, empty → `undefined`).
- **`daily-ranking/+page.svelte`** derives `currentYear` from `POPULATED_SEASONS` and passes it to the table.
- **`daily-ranking/Table.svelte`** highlights the matching row:
  - gradient background (`brand-600` 8% → 2%) + a 3px `brand-600` inset left accent
  - `navy-800` year, `brand-600` score, `brand-600` relative bar with a subtle ring
  - existing medal rank badge left unchanged
  - `sr-only` "(current season)" cue for screen-reader parity

## Verification

- `pnpm lint` clean · `pnpm test:unit` 91/91 pass
- Built + previewed; confirmed the **2026** row (rank 7, 82.200) highlighted at both desktop and mobile widths, all other rows unchanged. Computed styles verified: year `rgb(20,36,80)` = navy-800, score `rgb(29,87,232)` = brand-600, inset accent `rgb(29,87,232) 3px 0 0 0 inset`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)