### PR TITLE
Log DCI West score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -23,7 +23,12 @@ export const SEASON_2026: SeasonScores = {
       name: 'DCI Capital Classic',
       score: 82.2,
     },
-    { date: '2026-07-05', location: 'Stanford, CA', name: 'DCI West' },
+    {
+      date: '2026-07-05',
+      location: 'Stanford, CA',
+      name: 'DCI West',
+      score: 83.95,
+    },
     {
       date: '2026-07-09',
       location: 'Santa Clarita, CA',


### PR DESCRIPTION
Logs the Bluecoats' score of **83.95** at **DCI West** (Stanford, CA — 2026-07-05) by filling in the `score` on the existing scheduled entry in `src/lib/data/seasons/2026.ts`.

- `pnpm lint` ✅
- `pnpm test:unit` ✅ (87 passed)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LYfuwrv9GXkFW5zmChiLFa)_