### PR TITLE
Add Today home page and shared site footer

### DIFF
--- a/src/lib/components/daily-ranking/Table.svelte
+++ b/src/lib/components/daily-ranking/Table.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { DailyRankingItem } from '$lib/utils/daily-ranking';
   import { ordinalSuffix } from '$lib/utils/ordinal';
+  import { rankBadgeClass } from '$lib/utils/rank-style';
 
   let {
     rankings,
@@ -13,16 +14,6 @@
     const min = rankings[rankings.length - 1].score - 0.5;
     return { max, min };
   });
-
-  function rankClass(rank: number) {
-    if (rank === 1)
-      return 'bg-amber-100 text-amber-900 ring-1 ring-inset ring-amber-300';
-    if (rank === 2)
-      return 'bg-slate-100 text-slate-700 ring-1 ring-inset ring-slate-300';
-    if (rank === 3)
-      return 'bg-orange-50 text-orange-800 ring-1 ring-inset ring-orange-200';
-    return 'bg-gray-100 text-gray-600';
-  }
 
   const MEDAL_LABEL: Record<number, string> = {
     1: 'DCI World Champion',
@@ -87,7 +78,7 @@
             : ''}"
         >
           <span
-            class="inline-flex h-6 min-w-7 items-center justify-center rounded-md px-1.5 text-xs font-semibold tabular-nums {rankClass(
+            class="inline-flex h-6 min-w-7 items-center justify-center rounded-md px-1.5 text-xs font-semibold tabular-nums {rankBadgeClass(
               ranking.rank,
             )}"
             aria-label="{ranking.rank}{ordinalSuffix(ranking.rank)} place"

--- a/src/lib/components/daily-ranking/Table.svelte
+++ b/src/lib/components/daily-ranking/Table.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import type { DailyRankingItem } from '$lib/utils/daily-ranking';
   import { ordinalSuffix } from '$lib/utils/ordinal';
-  import { rankBadgeClass } from '$lib/utils/rank-style';
+  import {
+    MEDAL_EMOJI,
+    MEDAL_LABEL,
+    rankBadgeClass,
+  } from '$lib/utils/rank-style';
 
   let {
     rankings,
@@ -15,16 +19,6 @@
     return { max, min };
   });
 
-  const MEDAL_LABEL: Record<number, string> = {
-    1: 'DCI World Champion',
-    2: 'DCI Silver Medalist',
-    3: 'DCI Bronze Medalist',
-  };
-  const MEDAL_EMOJI: Record<number, string> = {
-    1: '🥇',
-    2: '🥈',
-    3: '🥉',
-  };
   const MEDAL_BAR_CLASS: Record<number, string> = {
     1: 'bg-amber-500',
     2: 'bg-slate-400',

--- a/src/lib/components/nav/MobileTabBar.svelte
+++ b/src/lib/components/nav/MobileTabBar.svelte
@@ -4,6 +4,8 @@
   import { NAV_ITEMS, type NavIconKind } from './types';
 
   function iconPath(kind: NavIconKind): string {
+    if (kind === 'today')
+      return 'M3 10.5 12 3l9 7.5 M5 8.75V21h14V8.75 M9.5 21v-5.5h5V21';
     if (kind === 'history')
       return 'M3 19h18 M5 17V9 M10 17V5 M15 17v-6 M20 17v-9';
     if (kind === 'tour')
@@ -13,7 +15,7 @@
 </script>
 
 <nav
-  class="absolute inset-x-0 bottom-0 z-20 grid grid-cols-3 border-t border-gray-200 bg-white/90 px-1 pt-1.5 pb-[calc(0.625rem+env(safe-area-inset-bottom,0))] backdrop-blur-lg backdrop-saturate-150 md:hidden"
+  class="absolute inset-x-0 bottom-0 z-20 grid grid-cols-4 border-t border-gray-200 bg-white/90 px-1 pt-1.5 pb-[calc(0.625rem+env(safe-area-inset-bottom,0))] backdrop-blur-lg backdrop-saturate-150 md:hidden"
   aria-label="Primary"
 >
   {#each NAV_ITEMS as item (item.href)}

--- a/src/lib/components/nav/types.ts
+++ b/src/lib/components/nav/types.ts
@@ -1,14 +1,20 @@
-export type NavIconKind = 'history' | 'daily' | 'tour';
+export type NavIconKind = 'today' | 'history' | 'daily' | 'tour';
 
 export interface NavItem {
   label: string;
   shortLabel: string;
-  href: '/' | '/daily-ranking' | '/tour';
+  href: '/' | '/score-history' | '/daily-ranking' | '/tour';
   icon: NavIconKind;
 }
 
 export const NAV_ITEMS: ReadonlyArray<NavItem> = [
-  { label: 'Score history', shortLabel: 'History', href: '/', icon: 'history' },
+  { label: 'Today', shortLabel: 'Today', href: '/', icon: 'today' },
+  {
+    label: 'Score history',
+    shortLabel: 'History',
+    href: '/score-history',
+    icon: 'history',
+  },
   {
     label: 'Daily ranking',
     shortLabel: 'Daily',

--- a/src/lib/components/shared/Footer.svelte
+++ b/src/lib/components/shared/Footer.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  const year = new Date().getFullYear();
+</script>
+
+<footer class="border-t border-gray-200">
+  <div
+    class="mx-auto flex max-w-300 flex-wrap items-center justify-center gap-x-2 gap-y-1 px-4 py-6 text-xs text-gray-400 md:px-6"
+  >
+    <span>© {year} Kevin Pfefferle</span>
+    <span aria-hidden="true">·</span>
+    <span>Independent alumni archive</span>
+    <span aria-hidden="true">·</span>
+    <a
+      href="https://github.com/kpfefferle/bluecoats"
+      target="_blank"
+      rel="noopener"
+      class="inline-flex items-center gap-1 font-medium text-gray-500 transition-colors hover:text-gray-900"
+    >
+      <svg
+        viewBox="0 0 16 16"
+        fill="currentColor"
+        class="size-3.5"
+        aria-hidden="true"
+      >
+        <path
+          d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"
+        />
+      </svg>
+      GitHub
+    </a>
+  </div>
+</footer>

--- a/src/lib/components/shared/Footer.svelte
+++ b/src/lib/components/shared/Footer.svelte
@@ -2,6 +2,9 @@
   const year = new Date().getFullYear();
 </script>
 
+<!-- Not redundant: the layout nests this inside <main>, which strips the
+     implicit contentinfo landmark, so it must be restored explicitly. -->
+<!-- svelte-ignore a11y_no_redundant_roles -->
 <footer class="border-t border-gray-200" role="contentinfo">
   <div
     class="mx-auto flex max-w-300 flex-wrap items-center justify-center gap-x-2 gap-y-1 px-4 py-6 text-xs text-gray-400 md:px-6"

--- a/src/lib/components/shared/Footer.svelte
+++ b/src/lib/components/shared/Footer.svelte
@@ -2,7 +2,7 @@
   const year = new Date().getFullYear();
 </script>
 
-<footer class="border-t border-gray-200">
+<footer class="border-t border-gray-200" role="contentinfo">
   <div
     class="mx-auto flex max-w-300 flex-wrap items-center justify-center gap-x-2 gap-y-1 px-4 py-6 text-xs text-gray-400 md:px-6"
   >

--- a/src/lib/components/today/ClosestSeasons.svelte
+++ b/src/lib/components/today/ClosestSeasons.svelte
@@ -1,0 +1,105 @@
+<script lang="ts">
+  import type { DailyRankingItem } from '$lib/utils/daily-ranking';
+  import { ordinalSuffix } from '$lib/utils/ordinal';
+  import { rankBadgeClass } from '$lib/utils/rank-style';
+
+  let {
+    items,
+    featuredYear,
+    featuredScore,
+  }: {
+    items: DailyRankingItem[];
+    featuredYear?: string;
+    featuredScore?: number;
+  } = $props();
+
+  function deltaLabel(score: number): string | null {
+    if (featuredScore === undefined) return null;
+    const diff = score - featuredScore;
+    if (diff === 0) return '—';
+    return `${diff > 0 ? '+' : '−'}${Math.abs(diff).toFixed(2)}`;
+  }
+</script>
+
+<table class="min-w-full">
+  <thead class="bg-gray-50">
+    <tr
+      class="border-b border-gray-200 text-left text-[0.6875rem] font-semibold tracking-wider text-gray-500 uppercase"
+    >
+      <th scope="col" class="py-3 pr-3 pl-4 whitespace-nowrap sm:pl-6">Rank</th>
+      <th scope="col" class="px-3 py-3 whitespace-nowrap">Year</th>
+      <th
+        scope="col"
+        class="hidden w-full px-3 py-3 whitespace-nowrap sm:table-cell"
+      >
+        Show
+      </th>
+      <th scope="col" class="px-3 py-3 text-right whitespace-nowrap">Score</th>
+      <th
+        scope="col"
+        class="px-3 py-3 pr-4 text-right whitespace-nowrap sm:pr-6"
+      >
+        {featuredYear ? `Δ vs. ${featuredYear}` : 'Δ'}
+      </th>
+    </tr>
+  </thead>
+  <tbody class="divide-y divide-gray-200 bg-white">
+    {#each items as item (item.year)}
+      {@const isCurrent = item.year === featuredYear}
+      {@const delta = isCurrent ? null : deltaLabel(item.score)}
+      <tr
+        class={isCurrent
+          ? 'bg-gradient-to-r from-brand-600/8 to-brand-600/2'
+          : 'hover:bg-gray-50'}
+      >
+        <td
+          class="py-3 pr-3 pl-4 align-middle sm:pl-6 {isCurrent
+            ? 'shadow-[inset_0.1875rem_0_0_0_var(--color-brand-600)]'
+            : ''}"
+        >
+          <span
+            class="inline-flex h-6 min-w-7 items-center justify-center rounded-md px-1.5 text-xs font-semibold tabular-nums {rankBadgeClass(
+              item.rank,
+            )}"
+            aria-label="{item.rank}{ordinalSuffix(item.rank)} place"
+          >
+            {item.rank}
+          </span>
+        </td>
+        <td
+          class="px-3 py-3 align-middle text-sm font-semibold whitespace-nowrap tabular-nums {isCurrent
+            ? 'text-navy-800'
+            : 'text-gray-900'}"
+        >
+          {item.year}{#if isCurrent}<span class="sr-only">
+              (current season)</span
+            >{/if}
+          {#if item.show}
+            <div
+              class="mt-0.5 truncate text-xs font-normal text-gray-500 sm:hidden"
+            >
+              {item.show}
+            </div>
+          {/if}
+        </td>
+        <td
+          class="hidden w-full px-3 py-3 align-middle text-sm text-gray-600 sm:table-cell"
+        >
+          {item.show ?? '—'}
+        </td>
+        <td
+          class="px-3 py-3 text-right align-middle text-sm font-semibold whitespace-nowrap tabular-nums {isCurrent
+            ? 'text-brand-600'
+            : 'text-gray-900'}"
+        >
+          {item.score.toFixed(3)}
+        </td>
+        <td
+          class="px-3 py-3 pr-4 text-right align-middle text-sm whitespace-nowrap text-gray-500 tabular-nums sm:pr-6"
+        >
+          {delta ?? '—'}
+        </td>
+      </tr>
+    {/each}
+  </tbody>
+</table>

--- a/src/lib/components/today/ClosestSeasons.svelte
+++ b/src/lib/components/today/ClosestSeasons.svelte
@@ -1,7 +1,11 @@
 <script lang="ts">
   import type { DailyRankingItem } from '$lib/utils/daily-ranking';
   import { ordinalSuffix } from '$lib/utils/ordinal';
-  import { rankBadgeClass } from '$lib/utils/rank-style';
+  import {
+    MEDAL_EMOJI,
+    MEDAL_LABEL,
+    rankBadgeClass,
+  } from '$lib/utils/rank-style';
 
   let {
     items,
@@ -34,10 +38,15 @@
       >
         Show
       </th>
-      <th scope="col" class="px-3 py-3 text-right whitespace-nowrap">Score</th>
       <th
         scope="col"
-        class="px-3 py-3 pr-4 text-right whitespace-nowrap sm:pr-6"
+        class="px-3 py-3 pr-4 text-right whitespace-nowrap sm:pr-3"
+      >
+        Score
+      </th>
+      <th
+        scope="col"
+        class="hidden px-3 py-3 pr-4 text-right whitespace-nowrap sm:table-cell sm:pr-6"
       >
         {featuredYear ? `Δ vs. ${featuredYear}` : 'Δ'}
       </th>
@@ -45,6 +54,8 @@
   </thead>
   <tbody class="divide-y divide-gray-200 bg-white">
     {#each items as item (item.year)}
+      {@const medal =
+        item.placement && item.placement <= 3 ? item.placement : null}
       {@const isCurrent = item.year === featuredYear}
       {@const delta = isCurrent ? null : deltaLabel(item.score)}
       <tr
@@ -71,7 +82,11 @@
             ? 'text-navy-800'
             : 'text-gray-900'}"
         >
-          {item.year}{#if isCurrent}<span class="sr-only">
+          {item.year}{#if medal}<span
+              class="ml-1.5"
+              role="img"
+              aria-label={MEDAL_LABEL[medal]}>{MEDAL_EMOJI[medal]}</span
+            >{/if}{#if isCurrent}<span class="sr-only">
               (current season)</span
             >{/if}
           {#if item.show}
@@ -88,14 +103,26 @@
           {item.show ?? '—'}
         </td>
         <td
-          class="px-3 py-3 text-right align-middle text-sm font-semibold whitespace-nowrap tabular-nums {isCurrent
-            ? 'text-brand-600'
-            : 'text-gray-900'}"
+          class="px-3 py-3 pr-4 text-right align-middle whitespace-nowrap tabular-nums sm:pr-3"
         >
-          {item.score.toFixed(3)}
+          <div
+            class="text-sm font-semibold {isCurrent
+              ? 'text-brand-600'
+              : 'text-gray-900'}"
+          >
+            {item.score.toFixed(3)}
+          </div>
+          {#if item.daysOld}
+            <div
+              class="mt-0.5 text-xs font-normal whitespace-nowrap text-gray-400"
+            >
+              {item.daysOld}
+              {item.daysOld === 1 ? 'day' : 'days'} prior
+            </div>
+          {/if}
         </td>
         <td
-          class="px-3 py-3 pr-4 text-right align-middle text-sm whitespace-nowrap text-gray-500 tabular-nums sm:pr-6"
+          class="hidden px-3 py-3 pr-4 text-right align-middle text-sm whitespace-nowrap text-gray-500 tabular-nums sm:table-cell sm:pr-6"
         >
           {delta ?? '—'}
         </td>

--- a/src/lib/components/today/TodayHero.svelte
+++ b/src/lib/components/today/TodayHero.svelte
@@ -28,8 +28,10 @@
     <div
       class="text-brand-300 text-[0.71875rem] font-semibold tracking-[0.08em] uppercase"
     >
-      {hero.year} season{#if hero.inProgress}&nbsp;·&nbsp;<FinalsCountdown
-        />{:else}&nbsp;·&nbsp;season complete{/if}
+      {hero.year} season{#if hero.inProgress}&nbsp;<span aria-hidden="true"
+          >·</span
+        >&nbsp;<FinalsCountdown />{:else}&nbsp;<span aria-hidden="true">·</span
+        >&nbsp;season complete{/if}
     </div>
     <h1
       class="mt-2 max-w-3xl text-2xl font-bold tracking-tight text-balance sm:text-[1.75rem]"

--- a/src/lib/components/today/TodayHero.svelte
+++ b/src/lib/components/today/TodayHero.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import FinalsCountdown from '$components/nav/FinalsCountdown.svelte';
+  import { daysAgo, type TodayHeroData } from '$lib/utils/today';
+
+  let { hero }: { hero: TodayHeroData } = $props();
+
+  const latestDaysAgo = $derived(browser ? daysAgo(hero.latest.date) : null);
+  const latestAgeLabel = $derived.by(() => {
+    if (latestDaysAgo === null) return null;
+    if (latestDaysAgo === 0) return 'today';
+    if (latestDaysAgo === 1) return 'yesterday';
+    return `${latestDaysAgo} days ago`;
+  });
+  const rankFoot = $derived.by(() => {
+    if (hero.rank === 1) return 'ahead of every past season at this stage';
+    if (hero.behindYears.length === 0) return null;
+    return `behind ${hero.behindYears.join(' and ')} at this stage`;
+  });
+</script>
+
+<section class="bg-navy-900 relative overflow-hidden rounded-xl text-white">
+  <div
+    class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_85%_0%,rgba(91,139,255,0.18),transparent_55%),radial-gradient(circle_at_0%_100%,rgba(199,154,58,0.1),transparent_50%)]"
+    aria-hidden="true"
+  ></div>
+  <div class="relative px-5 py-6 sm:px-8 sm:py-7">
+    <div
+      class="text-brand-300 text-[0.71875rem] font-semibold tracking-[0.08em] uppercase"
+    >
+      {hero.year} season{#if hero.inProgress}&nbsp;·&nbsp;<FinalsCountdown
+        />{:else}&nbsp;·&nbsp;season complete{/if}
+    </div>
+    <h1
+      class="mt-2 max-w-3xl text-2xl font-bold tracking-tight text-balance sm:text-[1.75rem]"
+    >
+      {#if hero.inProgress}
+        With <em class="text-brand-300 not-italic"
+          >{hero.latest.score.toFixed(3)}</em
+        >
+        in {hero.latest.location}, {hero.year} ranks
+        <em class="text-brand-300 not-italic"
+          >#{hero.rank} of {hero.totalSeasons}</em
+        > Bluecoats seasons at this point in the tour.
+      {:else}
+        {hero.year} closed at
+        <em class="text-brand-300 not-italic">{hero.latest.score.toFixed(3)}</em
+        >
+        — the corps'
+        <em class="text-brand-300 not-italic">#{hero.rank}</em> score all-time on
+        Finals night.
+      {/if}
+    </h1>
+    <p class="mt-2 max-w-xl text-sm text-white/70">
+      {#if hero.inProgress}
+        Scores climb all summer as shows are cleaned and rewritten. Here's how
+        this corps stacks up against every past Bluecoats season at the same
+        point in the tour.
+      {:else}
+        The {hero.year} tour is complete. Here's how the season stacked up against
+        every Bluecoats tour before it.
+      {/if}
+    </p>
+    <dl
+      class="mt-6 grid grid-cols-1 gap-4 border-t border-white/10 pt-4 sm:grid-cols-3 sm:gap-0 sm:pt-0"
+    >
+      <div class="sm:border-r sm:border-white/10 sm:py-4 sm:pr-5">
+        <dt class="text-[0.71875rem] font-medium text-white/60">
+          {hero.inProgress ? 'Latest score' : 'Final score'}
+        </dt>
+        <dd
+          class="mt-0.5 text-[1.625rem] font-semibold tracking-tight tabular-nums"
+        >
+          {hero.latest.score.toFixed(3)}
+        </dd>
+        <dd class="text-xs text-white/55">
+          {hero.latest.location}{#if latestAgeLabel}
+            · {latestAgeLabel}{/if}
+        </dd>
+      </div>
+      <div class="sm:border-r sm:border-white/10 sm:px-5 sm:py-4">
+        <dt class="text-[0.71875rem] font-medium text-white/60">
+          Rank vs. all seasons {hero.inProgress ? 'today' : 'at Finals'}
+        </dt>
+        <dd
+          class="mt-0.5 text-[1.625rem] font-semibold tracking-tight tabular-nums"
+        >
+          #{hero.rank}
+          <span class="text-sm font-medium text-white/55"
+            >of {hero.totalSeasons}</span
+          >
+        </dd>
+        {#if rankFoot}
+          <dd class="text-xs text-white/55">{rankFoot}</dd>
+        {/if}
+      </div>
+      {#if hero.best}
+        <div class="sm:py-4 sm:pl-5">
+          <dt class="text-[0.71875rem] font-medium text-white/60">
+            All-time best finals score
+          </dt>
+          <dd
+            class="mt-0.5 text-[1.625rem] font-semibold tracking-tight tabular-nums"
+          >
+            {hero.best.score.toFixed(3)}
+          </dd>
+          <dd class="text-xs text-white/55">
+            <span class="text-gold-400 font-semibold">{hero.best.year}</span
+            >{#if hero.best.show}
+              · {hero.best.show}{/if}
+          </dd>
+        </div>
+      {/if}
+    </dl>
+  </div>
+</section>

--- a/src/lib/components/today/TodayHero.svelte
+++ b/src/lib/components/today/TodayHero.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { browser } from '$app/environment';
   import FinalsCountdown from '$components/nav/FinalsCountdown.svelte';
+  import { ordinalSuffix } from '$lib/utils/ordinal';
   import { daysAgo, type TodayHeroData } from '$lib/utils/today';
 
   let { hero }: { hero: TodayHeroData } = $props();
@@ -19,7 +20,9 @@
   });
 </script>
 
-<section class="bg-navy-900 relative overflow-hidden rounded-xl text-white">
+<section
+  class="bg-navy-900 relative -mx-4 -mt-6 overflow-hidden rounded-none text-white md:mx-0 md:mt-0 md:rounded-xl"
+>
   <div
     class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_85%_0%,rgba(91,139,255,0.18),transparent_55%),radial-gradient(circle_at_0%_100%,rgba(199,154,58,0.1),transparent_50%)]"
     aria-hidden="true"
@@ -40,10 +43,16 @@
         With <em class="text-brand-300 not-italic"
           >{hero.latest.score.toFixed(3)}</em
         >
-        in {hero.latest.location}, {hero.year} ranks
-        <em class="text-brand-300 not-italic"
-          >#{hero.rank} of {hero.totalSeasons}</em
-        > Bluecoats seasons at this point in the tour.
+        in {hero.latest.location}, {hero.year} ranks as
+        {#if hero.rank === 1}
+          the <em class="text-brand-300 not-italic">best</em> Bluecoats season
+        {:else}
+          the
+          <em class="text-brand-300 not-italic"
+            >{hero.rank}{ordinalSuffix(hero.rank)} best</em
+          > Bluecoats season
+        {/if}
+        at this point in the tour.
       {:else}
         {hero.year} closed at
         <em class="text-brand-300 not-italic">{hero.latest.score.toFixed(3)}</em
@@ -66,7 +75,9 @@
     <dl
       class="mt-6 grid grid-cols-1 gap-4 border-t border-white/10 pt-4 sm:grid-cols-3 sm:gap-0 sm:pt-0"
     >
-      <div class="sm:border-r sm:border-white/10 sm:py-4 sm:pr-5">
+      <div
+        class="hidden sm:block sm:border-r sm:border-white/10 sm:py-4 sm:pr-5"
+      >
         <dt class="text-[0.71875rem] font-medium text-white/60">
           {hero.inProgress ? 'Latest score' : 'Final score'}
         </dt>
@@ -80,7 +91,9 @@
             · {latestAgeLabel}{/if}
         </dd>
       </div>
-      <div class="sm:border-r sm:border-white/10 sm:px-5 sm:py-4">
+      <div
+        class="hidden sm:block sm:border-r sm:border-white/10 sm:px-5 sm:py-4"
+      >
         <dt class="text-[0.71875rem] font-medium text-white/60">
           Rank vs. all seasons {hero.inProgress ? 'today' : 'at Finals'}
         </dt>

--- a/src/lib/utils/rank-style.ts
+++ b/src/lib/utils/rank-style.ts
@@ -1,0 +1,13 @@
+/**
+ * Badge classes for a leaderboard rank chip — podium tints for the top three,
+ * neutral gray otherwise. Shared by the daily-ranking and today tables.
+ */
+export function rankBadgeClass(rank: number): string {
+  if (rank === 1)
+    return 'bg-amber-100 text-amber-900 ring-1 ring-inset ring-amber-300';
+  if (rank === 2)
+    return 'bg-slate-100 text-slate-700 ring-1 ring-inset ring-slate-300';
+  if (rank === 3)
+    return 'bg-orange-50 text-orange-800 ring-1 ring-inset ring-orange-200';
+  return 'bg-gray-100 text-gray-600';
+}

--- a/src/lib/utils/rank-style.ts
+++ b/src/lib/utils/rank-style.ts
@@ -1,3 +1,17 @@
+/** Accessible labels for podium placements. Shared by the daily-ranking and today tables. */
+export const MEDAL_LABEL: Record<number, string> = {
+  1: 'DCI World Champion',
+  2: 'DCI Silver Medalist',
+  3: 'DCI Bronze Medalist',
+};
+
+/** Medal emoji for podium placements. Shared by the daily-ranking and today tables. */
+export const MEDAL_EMOJI: Record<number, string> = {
+  1: '🥇',
+  2: '🥈',
+  3: '🥉',
+};
+
 /**
  * Badge classes for a leaderboard rank chip — podium tints for the top three,
  * neutral gray otherwise. Shared by the daily-ranking and today tables.

--- a/src/lib/utils/today.ts
+++ b/src/lib/utils/today.ts
@@ -61,6 +61,25 @@ export interface TodayHeroData {
   best?: BestFinals;
 }
 
+/**
+ * The `count` seasons nearest the featured season by rank — a window centered
+ * on the featured entry, clamped to the list bounds. Equals the top of the
+ * leaderboard whenever the featured season ranks in the top three.
+ */
+export function closestSeasons(
+  rankings: DailyRankingItem[],
+  featuredYear: string,
+  count = 5,
+): DailyRankingItem[] {
+  const index = rankings.findIndex((item) => item.year === featuredYear);
+  if (index === -1) return rankings.slice(0, count);
+  const start = Math.min(
+    Math.max(index - Math.floor(count / 2), 0),
+    Math.max(rankings.length - count, 0),
+  );
+  return rankings.slice(start, start + count);
+}
+
 export interface TodayPageData {
   hero: TodayHeroData;
   /** Full leaderboard at `day`, best score first. */

--- a/src/lib/utils/today.ts
+++ b/src/lib/utils/today.ts
@@ -50,7 +50,6 @@ export function daysAgo(date: string, now: DateTime = DateTime.now()): number {
 
 export interface TodayHeroData {
   year: string;
-  show?: string;
   inProgress: boolean;
   latest: LatestResult;
   /** Rank of the featured season among all seasons as of `day`. */
@@ -107,7 +106,6 @@ export function buildTodayPage(
   return {
     hero: {
       year: featured.season.year,
-      show: featured.season.show,
       inProgress: featured.inProgress,
       latest,
       rank: rankings[index].rank,

--- a/src/lib/utils/today.ts
+++ b/src/lib/utils/today.ts
@@ -1,0 +1,103 @@
+import { DateTime } from 'luxon';
+import type { SeasonScores } from '$data/base';
+import { buildDailyRankings, type DailyRankingItem } from './daily-ranking';
+import type { FeaturedSeason } from './featured-season';
+import { FINALS_ZONE } from './time';
+import { finalsScore } from './tour';
+
+export interface LatestResult {
+  date: string;
+  location: string;
+  name?: string;
+  score: number;
+}
+
+/** The most recent numeric-scored entry of a season, else undefined. */
+export function latestScoredEntry(
+  season: SeasonScores,
+): LatestResult | undefined {
+  const scored = season.scores.filter(
+    (s): s is typeof s & { score: number } => typeof s.score === 'number',
+  );
+  return scored.at(-1);
+}
+
+export interface BestFinals {
+  year: string;
+  score: number;
+  show?: string;
+}
+
+/** The highest finals-night score across all seasons. */
+export function bestFinals(seasons: SeasonScores[]): BestFinals | undefined {
+  let best: BestFinals | undefined;
+  for (const season of seasons) {
+    const score = finalsScore(season);
+    if (score === null) continue;
+    if (!best || score > best.score) {
+      best = { year: season.year, score, show: season.show };
+    }
+  }
+  return best;
+}
+
+/** Whole calendar days elapsed since `date`, in the Finals time zone. */
+export function daysAgo(date: string, now: DateTime = DateTime.now()): number {
+  const then = DateTime.fromISO(date, { zone: FINALS_ZONE }).startOf('day');
+  const today = now.setZone(FINALS_ZONE).startOf('day');
+  return Math.max(0, Math.round(today.diff(then, 'days').days));
+}
+
+export interface TodayHeroData {
+  year: string;
+  show?: string;
+  inProgress: boolean;
+  latest: LatestResult;
+  /** Rank of the featured season among all seasons as of `day`. */
+  rank: number;
+  totalSeasons: number;
+  /** Up to two years ranked directly above the featured season, best first. */
+  behindYears: string[];
+  best?: BestFinals;
+}
+
+export interface TodayPageData {
+  hero: TodayHeroData;
+  /** Full leaderboard at `day`, best score first. */
+  rankings: DailyRankingItem[];
+}
+
+/**
+ * Everything the Today page derives from season data: hero stats plus the
+ * day's leaderboard. Pass `day = 0` for a completed featured season (rank on
+ * finals night) and the live days-until-finals while a tour is underway.
+ * Returns undefined when the featured season has no score as of `day`.
+ */
+export function buildTodayPage(
+  seasons: SeasonScores[],
+  featured: FeaturedSeason,
+  day: number,
+): TodayPageData | undefined {
+  const latest = latestScoredEntry(featured.season);
+  if (!latest) return undefined;
+  const rankings = buildDailyRankings(seasons, day);
+  const index = rankings.findIndex(
+    (item) => item.year === featured.season.year,
+  );
+  if (index === -1) return undefined;
+  return {
+    hero: {
+      year: featured.season.year,
+      show: featured.season.show,
+      inProgress: featured.inProgress,
+      latest,
+      rank: rankings[index].rank,
+      totalSeasons: rankings.length,
+      behindYears: rankings
+        .slice(Math.max(0, index - 2), index)
+        .map((item) => item.year),
+      best: bestFinals(seasons),
+    },
+    rankings,
+  };
+}

--- a/src/lib/utils/tour.ts
+++ b/src/lib/utils/tour.ts
@@ -130,7 +130,7 @@ export interface TourSummary {
 }
 
 /** The numeric score on finals night (0 days before finals), else null. */
-function finalsScore(season: SeasonScores): number | null {
+export function finalsScore(season: SeasonScores): number | null {
   const finalsStops = buildTour(season).filter(
     (s) => s.daysBeforeFinals === 0 && s.score !== null,
   );

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,6 +2,7 @@
   import '$src/app.css';
   import NavigationBar from '$components/nav/NavigationBar.svelte';
   import MobileTabBar from '$components/nav/MobileTabBar.svelte';
+  import Footer from '$components/shared/Footer.svelte';
   import type { Snippet } from 'svelte';
 
   let { children }: { children: Snippet } = $props();
@@ -17,6 +18,7 @@
     class="flex-1 overflow-y-auto overscroll-contain pb-[calc(4rem+env(safe-area-inset-bottom,0))] md:pb-0"
   >
     {@render children()}
+    <Footer />
   </main>
   <MobileTabBar />
 </div>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -29,7 +29,9 @@
       ? closestSeasons(today.rankings, featured.season.year)
       : [];
   const dayLabel =
-    day === 0 ? 'at Finals night' : `at ${day} days before Finals`;
+    day === 0
+      ? 'at Finals night'
+      : `at ${day} ${day === 1 ? 'day' : 'days'} before Finals`;
 </script>
 
 <svelte:head>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,112 +1,100 @@
 <script lang="ts">
-  import { browser } from '$app/environment';
-  import { page } from '$app/state';
+  import { resolve } from '$app/paths';
   import Card from '$components/shared/Card.svelte';
-  import ChartLegend from '$components/score-history/ChartLegend.svelte';
-  import DecadeYearPicker from '$components/score-history/DecadeYearPicker.svelte';
-  import EraSummary from '$components/score-history/EraSummary.svelte';
   import PageContent from '$components/shared/PageContent.svelte';
-  import PageHeader from '$components/shared/PageHeader.svelte';
   import SeasonScoresChart from '$components/score-history/SeasonScoresChart.svelte';
-  import { POPULATED_SEASONS } from '$data';
+  import ClosestSeasons from '$components/today/ClosestSeasons.svelte';
+  import TodayHero from '$components/today/TodayHero.svelte';
+  import { ALL_SEASONS_INCLUDING_SCHEDULED, POPULATED_SEASONS } from '$data';
+  import {
+    currentDayUntilFinals,
+    maxDayBeforeFinals,
+  } from '$lib/utils/daily-ranking';
   import { getFeaturedSeason } from '$lib/utils/featured-season';
-  import { setParam } from '$lib/utils/url-state';
+  import { buildTodayPage } from '$lib/utils/today';
 
-  // The most recent season that has competed is the chart's protagonist; while
-  // its tour is underway it also gets a "Today" marker.
   const featured = getFeaturedSeason(POPULATED_SEASONS);
-  const featuredYear = featured?.season.year;
-  const featuredInProgress = featured?.inProgress ?? false;
-
-  const yearsParam = $derived(
-    browser ? page.url.searchParams.get('years') : null,
+  const maxDay = maxDayBeforeFinals(POPULATED_SEASONS);
+  const currentDay = currentDayUntilFinals(
+    ALL_SEASONS_INCLUDING_SCHEDULED,
+    maxDay,
   );
-  const selectedYears = $derived((yearsParam ?? '').split(',').filter(Boolean));
-
-  // Compare lines are the picked seasons other than the always-on protagonist.
-  const compareYears = $derived(
-    selectedYears
-      .filter((year) => year !== featuredYear)
-      .slice()
-      .sort()
-      .reverse(),
-  );
-
-  const headline = $derived(
-    compareYears.length
-      ? `All seasons · comparing ${featuredYear} with ${compareYears.join(', ')}`
-      : `All seasons · ${featuredYear ?? 'latest'} featured`,
-  );
-
-  function onSelectedYearsChange(years: string[]) {
-    const next = years.slice().sort();
-    void setParam('years', next.length ? next.join(',') : null);
-  }
-
-  function clearSelection() {
-    void setParam('years', null);
-  }
+  // A completed featured season ranks on finals night; a live one ranks today.
+  const day = featured?.inProgress ? currentDay : 0;
+  const today = featured
+    ? buildTodayPage(POPULATED_SEASONS, featured, day)
+    : undefined;
+  const topFive = today?.rankings.slice(0, 5) ?? [];
+  const dayLabel =
+    day === 0 ? 'at Finals night' : `at ${day} days before Finals`;
 </script>
 
 <svelte:head>
-  <title>Score History | Bluecoats Scores</title>
+  <title>Today | Bluecoats Scores</title>
 </svelte:head>
 
-<PageHeader
-  title="Score history"
-  subtitle="Every Bluecoats season charted as a full tour toward DCI Finals"
-/>
-<PageContent>
-  <div class="grid grid-cols-1 gap-4">
-    <Card disablePadding>
-      <div
-        class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 px-4 py-4 sm:px-6"
-      >
-        <div>
-          <div class="text-sm font-semibold text-gray-900">{headline}</div>
-          <div class="text-xs text-gray-500">
-            Hover any line to surface it · gold marks championship seasons
-          </div>
-        </div>
-        <ChartLegend {featuredYear} />
-      </div>
-      <div class="flex h-200 flex-col overflow-x-auto px-2 pt-2">
-        <SeasonScoresChart
-          seasonScores={POPULATED_SEASONS}
-          {selectedYears}
-          {featuredYear}
-          {featuredInProgress}
-        />
-      </div>
-      <div class="px-4 pb-5 sm:px-6">
-        <EraSummary />
-      </div>
-    </Card>
+{#if featured && today}
+  <PageContent>
+    <div class="grid grid-cols-1 gap-4">
+      <TodayHero hero={today.hero} />
 
-    <Card>
-      <div class="mb-4 flex items-center justify-between gap-3">
-        <div>
-          <div class="text-sm font-semibold text-gray-900">Compare seasons</div>
-          <div class="text-xs text-gray-500">
-            Tap any year to promote it to a bold line on the chart above
+      <Card disablePadding>
+        <div
+          class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 px-4 py-4 sm:px-6"
+        >
+          <div>
+            <div class="text-sm font-semibold text-gray-900">
+              {today.hero.year} in context
+            </div>
+            <div class="text-xs text-gray-500">
+              Each thin line is one past season's tour · gold marks championship
+              seasons
+            </div>
           </div>
-        </div>
-        {#if compareYears.length}
-          <button
-            type="button"
+          <a
+            href={resolve('/score-history')}
             class="rounded-md px-2.5 py-1.5 text-xs font-semibold text-gray-600 hover:bg-gray-100"
-            onclick={clearSelection}
           >
-            Clear
-          </button>
-        {/if}
-      </div>
-      <DecadeYearPicker
-        seasonScores={POPULATED_SEASONS}
-        {selectedYears}
-        {featuredYear}
-        onChange={onSelectedYearsChange}
-      />
-    </Card>
-  </div>
-</PageContent>
+            Open full chart →
+          </a>
+        </div>
+        <div class="flex h-100 flex-col overflow-x-auto px-2 py-2">
+          <SeasonScoresChart
+            seasonScores={POPULATED_SEASONS}
+            selectedYears={[]}
+            featuredYear={featured.season.year}
+            featuredInProgress={featured.inProgress}
+          />
+        </div>
+      </Card>
+
+      <Card disablePadding>
+        <div
+          class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 px-4 py-4 sm:px-6"
+        >
+          <div>
+            <div class="text-sm font-semibold text-gray-900">
+              {today.hero.inProgress
+                ? `Closest to ${today.hero.year} right now`
+                : 'All-time finals leaderboard'}
+            </div>
+            <div class="text-xs text-gray-500">
+              Top 5 seasons {dayLabel}
+            </div>
+          </div>
+          <a
+            href={resolve('/daily-ranking')}
+            class="rounded-md px-2.5 py-1.5 text-xs font-semibold text-gray-600 hover:bg-gray-100"
+          >
+            View full ranking →
+          </a>
+        </div>
+        <ClosestSeasons
+          items={topFive}
+          featuredYear={featured.season.year}
+          featuredScore={today.hero.latest.score}
+        />
+      </Card>
+    </div>
+  </PageContent>
+{/if}

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,7 +11,7 @@
     maxDayBeforeFinals,
   } from '$lib/utils/daily-ranking';
   import { getFeaturedSeason } from '$lib/utils/featured-season';
-  import { buildTodayPage } from '$lib/utils/today';
+  import { buildTodayPage, closestSeasons } from '$lib/utils/today';
 
   const featured = getFeaturedSeason(POPULATED_SEASONS);
   const maxDay = maxDayBeforeFinals(POPULATED_SEASONS);
@@ -24,7 +24,10 @@
   const today = featured
     ? buildTodayPage(POPULATED_SEASONS, featured, day)
     : undefined;
-  const topFive = today?.rankings.slice(0, 5) ?? [];
+  const closest =
+    featured && today
+      ? closestSeasons(today.rankings, featured.season.year)
+      : [];
   const dayLabel =
     day === 0 ? 'at Finals night' : `at ${day} days before Finals`;
 </script>
@@ -79,7 +82,13 @@
                 : 'All-time finals leaderboard'}
             </div>
             <div class="text-xs text-gray-500">
-              Top 5 seasons {dayLabel}
+              {#if closest.length > 0 && closest[0] !== today.rankings[0]}
+                Seasons ranked #{closest[0].rank}–#{closest[closest.length - 1]
+                  .rank}
+                {dayLabel}
+              {:else}
+                Top {closest.length} seasons {dayLabel}
+              {/if}
             </div>
           </div>
           <a
@@ -90,7 +99,7 @@
           </a>
         </div>
         <ClosestSeasons
-          items={topFive}
+          items={closest}
           featuredYear={featured.season.year}
           featuredScore={today.hero.latest.score}
         />

--- a/src/routes/score-history/+page.svelte
+++ b/src/routes/score-history/+page.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+  import { browser } from '$app/environment';
+  import { page } from '$app/state';
+  import Card from '$components/shared/Card.svelte';
+  import ChartLegend from '$components/score-history/ChartLegend.svelte';
+  import DecadeYearPicker from '$components/score-history/DecadeYearPicker.svelte';
+  import EraSummary from '$components/score-history/EraSummary.svelte';
+  import PageContent from '$components/shared/PageContent.svelte';
+  import PageHeader from '$components/shared/PageHeader.svelte';
+  import SeasonScoresChart from '$components/score-history/SeasonScoresChart.svelte';
+  import { POPULATED_SEASONS } from '$data';
+  import { getFeaturedSeason } from '$lib/utils/featured-season';
+  import { setParam } from '$lib/utils/url-state';
+
+  // The most recent season that has competed is the chart's protagonist; while
+  // its tour is underway it also gets a "Today" marker.
+  const featured = getFeaturedSeason(POPULATED_SEASONS);
+  const featuredYear = featured?.season.year;
+  const featuredInProgress = featured?.inProgress ?? false;
+
+  const yearsParam = $derived(
+    browser ? page.url.searchParams.get('years') : null,
+  );
+  const selectedYears = $derived((yearsParam ?? '').split(',').filter(Boolean));
+
+  // Compare lines are the picked seasons other than the always-on protagonist.
+  const compareYears = $derived(
+    selectedYears
+      .filter((year) => year !== featuredYear)
+      .slice()
+      .sort()
+      .reverse(),
+  );
+
+  const headline = $derived(
+    compareYears.length
+      ? `All seasons · comparing ${featuredYear} with ${compareYears.join(', ')}`
+      : `All seasons · ${featuredYear ?? 'latest'} featured`,
+  );
+
+  function onSelectedYearsChange(years: string[]) {
+    const next = years.slice().sort();
+    void setParam('years', next.length ? next.join(',') : null);
+  }
+
+  function clearSelection() {
+    void setParam('years', null);
+  }
+</script>
+
+<svelte:head>
+  <title>Score History | Bluecoats Scores</title>
+</svelte:head>
+
+<PageHeader
+  title="Score history"
+  subtitle="Every Bluecoats season charted as a full tour toward DCI Finals"
+/>
+<PageContent>
+  <div class="grid grid-cols-1 gap-4">
+    <Card disablePadding>
+      <div
+        class="flex flex-wrap items-center justify-between gap-3 border-b border-gray-200 px-4 py-4 sm:px-6"
+      >
+        <div>
+          <div class="text-sm font-semibold text-gray-900">{headline}</div>
+          <div class="text-xs text-gray-500">
+            Hover any line to surface it · gold marks championship seasons
+          </div>
+        </div>
+        <ChartLegend {featuredYear} />
+      </div>
+      <div class="flex h-200 flex-col overflow-x-auto px-2 pt-2">
+        <SeasonScoresChart
+          seasonScores={POPULATED_SEASONS}
+          {selectedYears}
+          {featuredYear}
+          {featuredInProgress}
+        />
+      </div>
+      <div class="px-4 pb-5 sm:px-6">
+        <EraSummary />
+      </div>
+    </Card>
+
+    <Card>
+      <div class="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <div class="text-sm font-semibold text-gray-900">Compare seasons</div>
+          <div class="text-xs text-gray-500">
+            Tap any year to promote it to a bold line on the chart above
+          </div>
+        </div>
+        {#if compareYears.length}
+          <button
+            type="button"
+            class="rounded-md px-2.5 py-1.5 text-xs font-semibold text-gray-600 hover:bg-gray-100"
+            onclick={clearSelection}
+          >
+            Clear
+          </button>
+        {/if}
+      </div>
+      <DecadeYearPicker
+        seasonScores={POPULATED_SEASONS}
+        {selectedYears}
+        {featuredYear}
+        onChange={onSelectedYearsChange}
+      />
+    </Card>
+  </div>
+</PageContent>

--- a/tests/e2e/footer.test.ts
+++ b/tests/e2e/footer.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from '@playwright/test';
 
-test('every page shows the shared footer', async ({ page }) => {
+test('the root layout renders the shared footer', async ({ page }) => {
   await page.goto('/daily-ranking');
   const footer = page.locator('footer');
   await expect(footer.getByText(/© \d{4} Kevin Pfefferle/)).toBeVisible();

--- a/tests/e2e/footer.test.ts
+++ b/tests/e2e/footer.test.ts
@@ -1,0 +1,14 @@
+import { expect, test } from '@playwright/test';
+
+test('every page shows the shared footer', async ({ page }) => {
+  await page.goto('/daily-ranking');
+  const footer = page.locator('footer');
+  await expect(footer.getByText(/© \d{4} Kevin Pfefferle/)).toBeVisible();
+  await expect(footer.getByText('Independent alumni archive')).toBeVisible();
+  const github = footer.getByRole('link', { name: 'GitHub' });
+  await expect(github).toBeVisible();
+  await expect(github).toHaveAttribute(
+    'href',
+    'https://github.com/kpfefferle/bluecoats',
+  );
+});

--- a/tests/e2e/score-history.test.ts
+++ b/tests/e2e/score-history.test.ts
@@ -5,7 +5,7 @@ function selectedYears(url: string): string | null {
 }
 
 test('renders the chart and the decade season picker', async ({ page }) => {
-  await page.goto('/');
+  await page.goto('/score-history');
   await expect(
     page.getByRole('heading', { name: 'Score History' }),
   ).toBeVisible();
@@ -18,7 +18,7 @@ test('renders the chart and the decade season picker', async ({ page }) => {
 test('toggling a year pill adds and removes it from the URL', async ({
   page,
 }) => {
-  await page.goto('/');
+  await page.goto('/score-history');
   await page.getByRole('button', { name: '2014' }).click();
   await expect.poll(() => selectedYears(page.url())).toBe('2014');
 
@@ -29,14 +29,14 @@ test('toggling a year pill adds and removes it from the URL', async ({
 test('selecting multiple years records a sorted list in the URL', async ({
   page,
 }) => {
-  await page.goto('/');
+  await page.goto('/score-history');
   await page.getByRole('button', { name: '2016' }).click();
   await page.getByRole('button', { name: '2014' }).click();
   await expect.poll(() => selectedYears(page.url())).toBe('2014,2016');
 });
 
 test('reads selected years from the URL on load', async ({ page }) => {
-  await page.goto('/?years=2016,2018');
+  await page.goto('/score-history?years=2016,2018');
   await expect(page.getByRole('button', { name: '2016' })).toHaveAttribute(
     'aria-pressed',
     'true',

--- a/tests/e2e/today.test.ts
+++ b/tests/e2e/today.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test';
+
+test('renders the hero, context chart, and closest-seasons card', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+  // ECharts renders into a <canvas> inside the chart card
+  await expect(page.locator('canvas')).toBeVisible();
+  await expect(
+    page.getByRole('link', { name: 'Open full chart →' }),
+  ).toBeVisible();
+});
+
+test('open full chart navigates to the score history page', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await page.getByRole('link', { name: 'Open full chart →' }).click();
+  await expect(page).toHaveURL(/\/score-history$/);
+  await expect(
+    page.getByRole('heading', { name: 'Score History' }),
+  ).toBeVisible();
+});
+
+test('view full ranking navigates to the daily ranking page', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await page.getByRole('link', { name: 'View full ranking →' }).click();
+  await expect(page).toHaveURL(/\/daily-ranking$/);
+  await expect(
+    page.getByRole('heading', { name: 'Daily ranking' }),
+  ).toBeVisible();
+});

--- a/tests/e2e/today.test.ts
+++ b/tests/e2e/today.test.ts
@@ -33,3 +33,10 @@ test('view full ranking navigates to the daily ranking page', async ({
     page.getByRole('heading', { name: 'Daily ranking' }),
   ).toBeVisible();
 });
+
+test('drops the delta column at phone width', async ({ page }) => {
+  await page.setViewportSize({ width: 393, height: 852 });
+  await page.goto('/');
+  await expect(page.getByRole('columnheader', { name: /Δ vs\./ })).toBeHidden();
+  await expect(page.getByRole('columnheader', { name: 'Score' })).toBeVisible();
+});

--- a/tests/unit/today.test.ts
+++ b/tests/unit/today.test.ts
@@ -3,10 +3,12 @@ import { describe, expect, it } from 'vitest';
 import {
   bestFinals,
   buildTodayPage,
+  closestSeasons,
   daysAgo,
   latestScoredEntry,
 } from '../../src/lib/utils/today';
 import type { SeasonScores } from '../../src/lib/data/base';
+import type { DailyRankingItem } from '../../src/lib/utils/daily-ranking';
 
 const SEASON_2024: SeasonScores = {
   year: '2024',
@@ -155,5 +157,79 @@ describe('buildTodayPage', () => {
     expect(
       buildTodayPage(SEASONS, { season: SEASON_2026, inProgress: true }, 45),
     ).toBeUndefined();
+  });
+});
+
+function ranking(year: string, rank: number): DailyRankingItem {
+  return {
+    daysOld: 0,
+    location: 'Indianapolis, IN',
+    placement: undefined,
+    rank,
+    score: 100 - rank,
+    show: undefined,
+    year,
+  };
+}
+
+describe('closestSeasons', () => {
+  const RANKINGS = [
+    ranking('2020', 1),
+    ranking('2021', 2),
+    ranking('2022', 3),
+    ranking('2023', 4),
+    ranking('2024', 5),
+    ranking('2025', 6),
+    ranking('2026', 7),
+  ];
+
+  it('returns the first 5 when the featured season ranks 1st', () => {
+    expect(closestSeasons(RANKINGS, '2020').map((r) => r.year)).toEqual([
+      '2020',
+      '2021',
+      '2022',
+      '2023',
+      '2024',
+    ]);
+  });
+
+  it('centers the window on the featured season in the middle of a long list', () => {
+    // 2023 is rank 4 (index 3): expect 2 above, featured, 2 below.
+    expect(closestSeasons(RANKINGS, '2023').map((r) => r.year)).toEqual([
+      '2021',
+      '2022',
+      '2023',
+      '2024',
+      '2025',
+    ]);
+  });
+
+  it('returns the last 5 when the featured season ranks last', () => {
+    expect(closestSeasons(RANKINGS, '2026').map((r) => r.year)).toEqual([
+      '2022',
+      '2023',
+      '2024',
+      '2025',
+      '2026',
+    ]);
+  });
+
+  it('returns all rankings when there are fewer than the window count', () => {
+    const short = RANKINGS.slice(0, 3);
+    expect(closestSeasons(short, '2022').map((r) => r.year)).toEqual([
+      '2020',
+      '2021',
+      '2022',
+    ]);
+  });
+
+  it('falls back to the top 5 when the featured year is absent', () => {
+    expect(closestSeasons(RANKINGS, '1999').map((r) => r.year)).toEqual([
+      '2020',
+      '2021',
+      '2022',
+      '2023',
+      '2024',
+    ]);
   });
 });

--- a/tests/unit/today.test.ts
+++ b/tests/unit/today.test.ts
@@ -119,7 +119,6 @@ describe('buildTodayPage', () => {
     // At 21 days out: 2024 → 90.15, 2025 → 89.4, 2026 → 83.95 (its latest).
     expect(result?.hero).toMatchObject({
       year: '2026',
-      show: 'Gravity & Grace',
       inProgress: true,
       rank: 3,
       totalSeasons: 3,

--- a/tests/unit/today.test.ts
+++ b/tests/unit/today.test.ts
@@ -1,0 +1,159 @@
+import { DateTime } from 'luxon';
+import { describe, expect, it } from 'vitest';
+import {
+  bestFinals,
+  buildTodayPage,
+  daysAgo,
+  latestScoredEntry,
+} from '../../src/lib/utils/today';
+import type { SeasonScores } from '../../src/lib/data/base';
+
+const SEASON_2024: SeasonScores = {
+  year: '2024',
+  endDate: '2024-08-10',
+  show: 'Riffs and Revelations',
+  placement: 2,
+  scores: [
+    { date: '2024-07-20', location: 'San Antonio, TX', score: 90.15 },
+    { date: '2024-08-10', location: 'Indianapolis, IN', score: 98.75 },
+  ],
+};
+
+const SEASON_2025: SeasonScores = {
+  year: '2025',
+  endDate: '2025-08-09',
+  show: 'Tongue and Cheek',
+  placement: 2,
+  scores: [
+    { date: '2025-07-19', location: 'San Antonio, TX', score: 89.4 },
+    { date: '2025-08-09', location: 'Indianapolis, IN', score: 98.25 },
+  ],
+};
+
+// In progress: two scored shows, an exhibition, and an unscored finals entry.
+const SEASON_2026: SeasonScores = {
+  year: '2026',
+  endDate: '2026-08-08',
+  show: 'Gravity & Grace',
+  scores: [
+    { date: '2026-06-27', location: 'Alliance, OH', score: null },
+    {
+      date: '2026-07-03',
+      location: 'Sacramento, CA',
+      name: 'DCI Capital Classic',
+      score: 82.2,
+    },
+    {
+      date: '2026-07-05',
+      location: 'Stanford, CA',
+      name: 'DCI West',
+      score: 83.95,
+    },
+    { date: '2026-08-08', location: 'Indianapolis, IN' },
+  ],
+};
+
+const SEASONS = [SEASON_2024, SEASON_2025, SEASON_2026];
+
+describe('latestScoredEntry', () => {
+  it('returns the most recent numeric-scored entry', () => {
+    const latest = latestScoredEntry(SEASON_2026);
+    expect(latest).toMatchObject({
+      date: '2026-07-05',
+      location: 'Stanford, CA',
+      score: 83.95,
+    });
+  });
+
+  it('returns undefined when a season has no numeric scores', () => {
+    const scheduled: SeasonScores = {
+      year: '2027',
+      endDate: '2027-08-14',
+      scores: [{ date: '2027-06-26', location: 'Alliance, OH' }],
+    };
+    expect(latestScoredEntry(scheduled)).toBeUndefined();
+  });
+});
+
+describe('bestFinals', () => {
+  it('returns the highest finals-night score across seasons', () => {
+    expect(bestFinals(SEASONS)).toEqual({
+      year: '2024',
+      score: 98.75,
+      show: 'Riffs and Revelations',
+    });
+  });
+
+  it('ignores seasons that have not scored on finals night', () => {
+    expect(bestFinals([SEASON_2026])).toBeUndefined();
+  });
+});
+
+describe('daysAgo', () => {
+  const now = DateTime.fromISO('2026-07-09T12:00:00', {
+    zone: 'America/New_York',
+  });
+
+  it('counts whole calendar days since the date', () => {
+    expect(daysAgo('2026-07-05', now)).toBe(4);
+  });
+
+  it('returns 0 for the same day', () => {
+    expect(daysAgo('2026-07-09', now)).toBe(0);
+  });
+
+  it('clamps future dates to 0', () => {
+    expect(daysAgo('2026-07-12', now)).toBe(0);
+  });
+});
+
+describe('buildTodayPage', () => {
+  it('ranks an in-progress featured season at the given day', () => {
+    const result = buildTodayPage(
+      SEASONS,
+      { season: SEASON_2026, inProgress: true },
+      21,
+    );
+    // At 21 days out: 2024 → 90.15, 2025 → 89.4, 2026 → 83.95 (its latest).
+    expect(result?.hero).toMatchObject({
+      year: '2026',
+      show: 'Gravity & Grace',
+      inProgress: true,
+      rank: 3,
+      totalSeasons: 3,
+      behindYears: ['2024', '2025'],
+      best: { year: '2024', score: 98.75 },
+    });
+    expect(result?.hero.latest).toMatchObject({
+      score: 83.95,
+      location: 'Stanford, CA',
+    });
+    expect(result?.rankings.map((r) => r.year)).toEqual([
+      '2024',
+      '2025',
+      '2026',
+    ]);
+  });
+
+  it('ranks a completed featured season on finals night (day 0)', () => {
+    const result = buildTodayPage(
+      SEASONS,
+      { season: SEASON_2025, inProgress: false },
+      0,
+    );
+    expect(result?.hero).toMatchObject({
+      year: '2025',
+      inProgress: false,
+      rank: 2,
+      behindYears: ['2024'],
+    });
+    expect(result?.hero.latest.score).toBe(98.25);
+  });
+
+  it('returns undefined when the featured season has no score by that day', () => {
+    // At 45 days out no fixture season has produced a score yet.
+    expect(
+      buildTodayPage(SEASONS, { season: SEASON_2026, inProgress: true }, 45),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Implements the **Today (home)** page from the [Bluecoats Reimagined design](https://claude.ai/design/p/019dee2f-56a9-792c-a7ad-91f74cdd30cb?file=Bluecoats+Reimagined.html) using the site's existing component patterns, plus a shared page footer.

- **`/` is now the Today page**: a navy hero (latest score, rank vs. all seasons at this point in the tour, all-time best finals score), a season-in-context card reusing `SeasonScoresChart`, and a closest-seasons table derived from `buildDailyRankings`. Score history moved unchanged to **`/score-history`**; desktop nav and the mobile tab bar gain a Today entry.
- **Shared footer** on every page via the root layout: `© 2026 Kevin Pfefferle · Independent alumni archive · GitHub`.
- New pure helpers in `src/lib/utils/today.ts` (unit-tested); `rankBadgeClass` extracted to `src/lib/utils/rank-style.ts` and shared with the daily-ranking table.
- Off-season behavior is handled: when no tour is underway the hero switches to a finals-night recap and the table becomes an all-time finals leaderboard.

### Deviations from the design mock

- The mock's **"Projected Finals score"** stat relied on a synthesized projection model that doesn't exist here; it's replaced with the real **"All-time best finals score"** (98.75 · 2024).
- The closest-seasons card uses a **rank-centered window** rather than a plain top-5, so the current season is always visible in its own card (identical to the mock whenever the corps ranks top-3).

### Follow-up candidates (not included)

- Redirect legacy `/?years=…` deep links to `/score-history` with params preserved.

## Test plan

- [x] `pnpm test` — 106 unit + 13 e2e (new `today` and `footer` suites; `score-history` suite updated to its new URL)
- [x] `pnpm lint` — eslint, stylelint, prettier, svelte-check (0 warnings), knip
- [x] `pnpm build` — all four routes prerender cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)