### PR TITLE
Fix hero dot spacing and age-aware chart marker label

### DIFF
--- a/src/lib/components/score-history/SeasonScoresChart.svelte
+++ b/src/lib/components/score-history/SeasonScoresChart.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
+  import { browser } from '$app/environment';
   import { chart } from '$lib/actions/chart';
   import { buildChartOption } from '$lib/utils/chart-options';
+  import { ageLabel, daysAgo, latestScoredEntry } from '$lib/utils/today';
   import type { SeasonScores } from '$data/base';
 
   let {
@@ -15,12 +17,26 @@
     featuredInProgress?: boolean;
   } = $props();
 
+  // How long ago the featured season's latest score landed, capitalized for the
+  // marker ("Today", "Yesterday", "3 days ago"). The chart renders client-side
+  // only, so reading the clock in the browser needs no hydration guard, but we
+  // fall back to the default label during prerender all the same.
+  const featuredAgeLabel = $derived.by(() => {
+    if (!browser || !featuredInProgress) return undefined;
+    const featured = seasonScores.find((s) => s.year === featuredYear);
+    const latest = featured && latestScoredEntry(featured);
+    if (!latest) return undefined;
+    const label = ageLabel(daysAgo(latest.date));
+    return label.charAt(0).toUpperCase() + label.slice(1);
+  });
+
   const chartOption = $derived(
     buildChartOption({
       seasons: seasonScores,
       selectedYears,
       featuredYear,
       featuredInProgress,
+      featuredAgeLabel,
     }),
   );
 </script>

--- a/src/lib/components/today/TodayHero.svelte
+++ b/src/lib/components/today/TodayHero.svelte
@@ -2,17 +2,14 @@
   import { browser } from '$app/environment';
   import FinalsCountdown from '$components/nav/FinalsCountdown.svelte';
   import { ordinalSuffix } from '$lib/utils/ordinal';
-  import { daysAgo, type TodayHeroData } from '$lib/utils/today';
+  import { ageLabel, daysAgo, type TodayHeroData } from '$lib/utils/today';
 
   let { hero }: { hero: TodayHeroData } = $props();
 
   const latestDaysAgo = $derived(browser ? daysAgo(hero.latest.date) : null);
-  const latestAgeLabel = $derived.by(() => {
-    if (latestDaysAgo === null) return null;
-    if (latestDaysAgo === 0) return 'today';
-    if (latestDaysAgo === 1) return 'yesterday';
-    return `${latestDaysAgo} days ago`;
-  });
+  const latestAgeLabel = $derived(
+    latestDaysAgo === null ? null : ageLabel(latestDaysAgo),
+  );
   const rankFoot = $derived.by(() => {
     if (hero.rank === 1) return 'ahead of every past season at this stage';
     if (hero.behindYears.length === 0) return null;
@@ -87,8 +84,7 @@
           {hero.latest.score.toFixed(3)}
         </dd>
         <dd class="text-xs text-white/55">
-          {hero.latest.location}{#if latestAgeLabel}
-            · {latestAgeLabel}{/if}
+          {hero.latest.location}{#if latestAgeLabel}&nbsp;· {latestAgeLabel}{/if}
         </dd>
       </div>
       <div
@@ -121,8 +117,7 @@
           </dd>
           <dd class="text-xs text-white/55">
             <span class="text-gold-400 font-semibold">{hero.best.year}</span
-            >{#if hero.best.show}
-              · {hero.best.show}{/if}
+            >{#if hero.best.show}&nbsp;· {hero.best.show}{/if}
           </dd>
         </div>
       {/if}

--- a/src/lib/utils/chart-options.ts
+++ b/src/lib/utils/chart-options.ts
@@ -102,6 +102,7 @@ function seriesForSeason(
   season: SeasonScores,
   role: Role,
   inProgress: boolean,
+  ageLabel: string,
 ): SeriesOption {
   const base = {
     ...LINE_SERIES_OPTION_BASE,
@@ -177,7 +178,7 @@ function seriesForSeason(
           label: {
             show: true,
             position: 'top' as const,
-            formatter: `Today · ${latest.score.toFixed(3)}`,
+            formatter: `${ageLabel} · ${latest.score.toFixed(3)}`,
             color: '#fff',
             backgroundColor: COLOR_INK,
             borderRadius: 4,
@@ -187,7 +188,7 @@ function seriesForSeason(
           },
           data: [
             {
-              name: 'Today',
+              name: ageLabel,
               coord: [-daysBeforeFinals(season, latest.date), latest.score] as [
                 number,
                 number,
@@ -244,8 +245,14 @@ export interface ChartOptionInput {
   selectedYears: SeasonScores['year'][];
   /** The protagonist season's year, highlighted in bold blue. */
   featuredYear?: SeasonScores['year'];
-  /** True when the featured season's tour is still underway (shows Today marker). */
+  /** True when the featured season's tour is still underway (shows the marker). */
   featuredInProgress?: boolean;
+  /**
+   * Capitalized label for the featured marker describing how long ago the
+   * latest score landed, e.g. `"Today"`, `"Yesterday"`, `"3 days ago"`.
+   * Defaults to `"Today"`.
+   */
+  featuredAgeLabel?: string;
 }
 
 export function buildChartOption({
@@ -253,6 +260,7 @@ export function buildChartOption({
   selectedYears,
   featuredYear,
   featuredInProgress = false,
+  featuredAgeLabel = 'Today',
 }: ChartOptionInput): EChartsOption {
   const roleFor = (season: SeasonScores): Role => {
     if (season.year === featuredYear) return 'featured';
@@ -272,7 +280,7 @@ export function buildChartOption({
     .map((season) => ({ season, role: roleFor(season) }))
     .sort((a, b) => order[a.role] - order[b.role])
     .map(({ season, role }) =>
-      seriesForSeason(season, role, featuredInProgress),
+      seriesForSeason(season, role, featuredInProgress, featuredAgeLabel),
     );
 
   // Scale the axes to the featured season alone until the viewer picks seasons

--- a/src/lib/utils/today.ts
+++ b/src/lib/utils/today.ts
@@ -48,6 +48,18 @@ export function daysAgo(date: string, now: DateTime = DateTime.now()): number {
   return Math.max(0, Math.round(today.diff(then, 'days').days));
 }
 
+/**
+ * Human label for how long ago a result landed, given a whole-day count:
+ * `0 → "today"`, `1 → "yesterday"`, `n → "n days ago"`. Lowercase so it reads
+ * naturally mid-sentence; capitalize at the call site where a leading label is
+ * wanted.
+ */
+export function ageLabel(days: number): string {
+  if (days <= 0) return 'today';
+  if (days === 1) return 'yesterday';
+  return `${days} days ago`;
+}
+
 export interface TodayHeroData {
   year: string;
   inProgress: boolean;

--- a/tests/unit/chart-options.test.ts
+++ b/tests/unit/chart-options.test.ts
@@ -49,7 +49,10 @@ type Series = {
   lineStyle?: { color?: string; width?: number; opacity?: number };
   itemStyle?: { color?: string };
   endLabel?: { show?: boolean };
-  markPoint?: { data: Array<{ coord: [number, number] }> };
+  markPoint?: {
+    label?: { formatter?: string };
+    data: Array<{ coord: [number, number]; name?: string }>;
+  };
 };
 
 function seriesByName(opt: ReturnType<typeof buildChartOption>, name: string) {
@@ -111,6 +114,9 @@ describe('buildChartOption', () => {
     });
     const marker = seriesByName(live, '2026').markPoint;
     expect(marker?.data[0].coord).toEqual([-14, 88.0]);
+    // Defaults to "Today" when no age label is supplied.
+    expect(marker?.data[0].name).toBe('Today');
+    expect(marker?.label?.formatter).toBe('Today · 88.000');
 
     const offSeason = buildChartOption({
       seasons: [partial],
@@ -119,6 +125,24 @@ describe('buildChartOption', () => {
       featuredInProgress: false,
     });
     expect(seriesByName(offSeason, '2026').markPoint).toBeUndefined();
+  });
+
+  it('labels the marker with the supplied age label as days pass', () => {
+    const partial: SeasonScores = {
+      year: '2026',
+      endDate: '2026-08-08',
+      scores: [{ date: '2026-07-25', location: 'Atlanta, GA', score: 88.0 }],
+    };
+    const opt = buildChartOption({
+      seasons: [partial],
+      selectedYears: [],
+      featuredYear: '2026',
+      featuredInProgress: true,
+      featuredAgeLabel: '3 days ago',
+    });
+    const marker = seriesByName(opt, '2026').markPoint;
+    expect(marker?.data[0].name).toBe('3 days ago');
+    expect(marker?.label?.formatter).toBe('3 days ago · 88.000');
   });
 
   it('renders championship seasons (placement 1) in gold when not selected', () => {

--- a/tests/unit/today.test.ts
+++ b/tests/unit/today.test.ts
@@ -1,6 +1,7 @@
 import { DateTime } from 'luxon';
 import { describe, expect, it } from 'vitest';
 import {
+  ageLabel,
   bestFinals,
   buildTodayPage,
   closestSeasons,
@@ -106,6 +107,21 @@ describe('daysAgo', () => {
 
   it('clamps future dates to 0', () => {
     expect(daysAgo('2026-07-12', now)).toBe(0);
+  });
+});
+
+describe('ageLabel', () => {
+  it('reads "today" for the current day', () => {
+    expect(ageLabel(0)).toBe('today');
+  });
+
+  it('reads "yesterday" for one day back', () => {
+    expect(ageLabel(1)).toBe('yesterday');
+  });
+
+  it('pluralizes for older results', () => {
+    expect(ageLabel(2)).toBe('2 days ago');
+    expect(ageLabel(11)).toBe('11 days ago');
   });
 });
 


### PR DESCRIPTION
Two small polish fixes to the Today page hero and the Score History chart:

- The "latest score" and "all-time best" hero cards rendered their
  year/location directly against the "·" separator ("2024· Change Is
  Everything") because Svelte trims the leading whitespace inside the
  {#if} block. Anchor the separator with a non-breaking space so it
  reads "2024 · Change Is Everything".

- The featured-season chart marker always read "Today" regardless of
  how stale the latest score was. It now labels the marker "Today",
  "Yesterday", "2 days ago", etc., derived from how many days have
  passed since the latest result. A shared ageLabel() helper backs both
  the hero footnote and the chart marker; the label is passed into the
  pure buildChartOption() so it stays testable.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RtK4Cs3mdi4thR5u6kVnQv