### PR TITLE
Add a branded error page with an SPA-shell 404 fallback

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -97,6 +97,7 @@ src/
 │   ├── actions/                      # chart.ts (ECharts lifecycle)
 │   └── utils/                        # url-state.ts, ordinal.ts, daily-ranking.ts, chart-options.ts
 └── routes/
+    ├── +error.svelte                 # Branded error page (404s render here)
     ├── +layout.svelte                # Renders <NavigationBar /> + children
     ├── +layout.ts                    # `export const prerender = true`
     ├── +page.svelte                  # Today home page
@@ -179,7 +180,7 @@ const dayParam = $derived(browser ? page.url.searchParams.get('day') : null);
 
 The prerendered HTML reflects the default state (no query params); on hydration, the client picks up the real URL and re-derives.
 
-Season selection on the Tour page and day selection on the Daily Ranking page are **path** state, not query state: each season lives at `/tour/[year]` and each day at `/daily-ranking/[day]` (both prerendered via `entries()`); `/tour` and `/daily-ranking` redirect to the latest season / current day. Link with `resolve('/tour/[year]', { year })` or `resolve('/daily-ranking/[day]', { day })`.
+Season selection on the Tour page and day selection on the Daily Ranking page are **path** state, not query state: each season lives at `/tour/[year]` and each day at `/daily-ranking/[day]` (both prerendered via `entries()`); `/tour` and `/daily-ranking` redirect to the latest season / current day. Link with `resolve('/tour/[year]', { year })` or `resolve('/daily-ranking/[day]', { day })`. Unknown paths never reach the worker (the `_routes.json` include-list), so Cloudflare serves the adapter's SPA-shell `404.html` (`fallback: 'spa'` in `svelte.config.js`), which hydrates into `src/routes/+error.svelte`.
 
 #### Chart Action
 

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { resolve } from '$app/paths';
+  import { page } from '$app/state';
+  import PageContent from '$components/shared/PageContent.svelte';
+  import PageHeader from '$components/shared/PageHeader.svelte';
+
+  const notFound = $derived(page.status === 404);
+  const title = $derived(notFound ? 'Page not found' : 'Something went wrong');
+  const subtitle = $derived(
+    notFound
+      ? 'This page never made it past prelims.'
+      : `${page.status}: ${page.error?.message ?? 'Unexpected error'}`,
+  );
+</script>
+
+<svelte:head>
+  <title>{notFound ? 'Page not found' : 'Error'} | Bluecoats Scores</title>
+</svelte:head>
+
+<PageHeader {title} {subtitle} />
+<PageContent>
+  <a
+    href={resolve('/')}
+    class="text-sm font-semibold text-brand-600 hover:text-brand-500"
+  >
+    Back to Today →
+  </a>
+</PageContent>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -6,6 +6,10 @@ const config = {
   preprocess: vitePreprocess(),
   kit: {
     adapter: adapter({
+      // Unknown paths bypass the worker (routes.include below), so the static
+      // 404.html Cloudflare serves for asset misses must be an SPA shell that
+      // hydrates into src/routes/+error.svelte instead of unstyled plaintext.
+      fallback: 'spa',
       // Only the two server-side redirect routes invoke the Pages worker; every
       // other path is served as a static asset. Without this, the adapter emits
       // one exclude rule per prerendered page (~180) and Cloudflare's 100-rule

--- a/tests/e2e/error.test.ts
+++ b/tests/e2e/error.test.ts
@@ -24,7 +24,7 @@ test('the error page keeps the nav with no active item', async ({ page }) => {
 test('Back to Today returns home', async ({ page }) => {
   await page.goto('/definitely-not-a-page');
   await page.getByRole('link', { name: 'Back to Today →' }).click();
-  await expect(page).toHaveURL(/\/$/);
+  await expect(page).toHaveURL(/^http:\/\/[^/]+\/$/);
 });
 
 test('an invalid tour year shows the branded 404', async ({ page }) => {

--- a/tests/e2e/error.test.ts
+++ b/tests/e2e/error.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test';
+
+test('an unknown path renders the branded 404 page', async ({ page }) => {
+  const response = await page.goto('/definitely-not-a-page');
+  expect(response?.status()).toBe(404);
+  await expect(page).toHaveTitle('Page not found | Bluecoats Scores');
+  await expect(
+    page.getByRole('heading', { name: 'Page not found' }),
+  ).toBeVisible();
+  await expect(
+    page.getByText('This page never made it past prelims.'),
+  ).toBeVisible();
+});
+
+test('the error page keeps the nav with no active item', async ({ page }) => {
+  await page.goto('/definitely-not-a-page');
+  await expect(
+    page.getByRole('navigation', { name: 'Primary' }).first(),
+  ).toBeVisible();
+  // page.route.id is null on error pages, so no nav item (or chip) is current.
+  await expect(page.locator('[aria-current="page"]')).toHaveCount(0);
+});
+
+test('Back to Today returns home', async ({ page }) => {
+  await page.goto('/definitely-not-a-page');
+  await page.getByRole('link', { name: 'Back to Today →' }).click();
+  await expect(page).toHaveURL(/\/$/);
+});
+
+test('an invalid tour year shows the branded 404', async ({ page }) => {
+  await page.goto('/tour/banana');
+  await expect(
+    page.getByRole('heading', { name: 'Page not found' }),
+  ).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Follow-up to #374/#375: 404s are now a designed surface (invalid tour years, invalid ranking days, unknown paths), but the site had no error page — dev/preview showed SvelteKit's bare fallback, and in production unknown paths got the adapter's *plaintext* `404.html` (they bypass the worker entirely due to the `_routes.json` include-list).

- **`src/routes/+error.svelte`** — branded error page rendered inside the root layout (nav, tab bar, footer all present). 404s read "Page not found · This page never made it past prelims." with a "Back to Today →" link; any other status reads "Something went wrong" with the status and message. Titles: `Page not found | Bluecoats Scores` / `Error | Bluecoats Scores`.
- **`fallback: 'spa'`** in the adapter options — the generated `404.html` is now an SPA shell instead of plaintext, which Cloudflare Pages serves (with a preserved 404 status) for any asset miss and hydrates into the error page. This is the adapter's documented mechanism for exactly our manual-`routes` setup.
- No changes to `_routes.json`, the redirect routes, or any 404 logic.

## Test plan

- [x] New `tests/e2e/error.test.ts` (4 tests): unknown path → 404 status + branded heading/flavor/title; nav visible with no `aria-current` item; "Back to Today" navigates to the site root; `/tour/banana` renders the branded page
- [x] Full suite green on a cold build: unit 128/128, e2e 37/37, all linters + svelte-check clean
- [x] Production-only path verified by inspection + simulation (preview can't exercise it): the built `404.html` is the app shell, and serving the build output statically with 404.html-on-miss hydrates `/definitely-not-a-page`, `/tour/banana`, and `/tour/9999` into the branded page with 404 status; `_routes.json` byte-identical; `_headers` unaffected

## Notes

- The non-404 branch ("Something went wrong") has no automated coverage — there's no cheap way to force a 500 through a fully prerendered preview. Accepted gap; a component-level test is a possible follow-up.
- No-JS visitors on unknown paths get the empty shell with a correct 404 status (the trade-off accepted in the design over a prerendered static `/404`, which risks colliding with the adapter's own `404.html`).
- The nested `<main>` (layout + `PageContent`) is a pre-existing site-wide pattern, not introduced here — noted for a future a11y pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)