### PR TITLE
Extract shared parseCanonicalDay and seasonForYear helpers

### DIFF
--- a/src/lib/utils/daily-ranking.ts
+++ b/src/lib/utils/daily-ranking.ts
@@ -117,3 +117,25 @@ export function dayRankingLabel(day: number): string {
   if (day === 2) return 'Prelims';
   return `Day ${day}`;
 }
+
+/**
+ * Parse a raw day param (from /daily-ranking/[day] or a legacy ?day= query)
+ * into a day number. Canonical non-negative integers only: rejects null,
+ * "banana", "07", "-1", "3.5", and anything beyond maxDay.
+ */
+export function parseCanonicalDay(
+  raw: string | null,
+  maxDay: number,
+): number | undefined {
+  if (raw === null) return undefined;
+  const day = Number(raw);
+  if (
+    !Number.isInteger(day) ||
+    day < 0 ||
+    day > maxDay ||
+    String(day) !== raw
+  ) {
+    return undefined;
+  }
+  return day;
+}

--- a/src/lib/utils/tour.ts
+++ b/src/lib/utils/tour.ts
@@ -209,3 +209,15 @@ export function placementLabel(placement: number | undefined): string | null {
     return `Top 12 · ${placement}${ordinalSuffix(placement)} place`;
   return `${placement}${ordinalSuffix(placement)} place`;
 }
+
+/**
+ * Look up a season by its exact year string (from /tour/[year] or a legacy
+ * ?year= query). Years are valid by membership, not parsing.
+ */
+export function seasonForYear(
+  seasons: SeasonScores[],
+  year: string | null,
+): SeasonScores | undefined {
+  if (year === null) return undefined;
+  return seasons.find((season) => season.year === year);
+}

--- a/src/routes/daily-ranking/+page.ts
+++ b/src/routes/daily-ranking/+page.ts
@@ -4,6 +4,7 @@ import { ALL_SEASONS_INCLUDING_SCHEDULED, POPULATED_SEASONS } from '$data';
 import {
   currentDayUntilFinals,
   maxDayBeforeFinals,
+  parseCanonicalDay,
 } from '$lib/utils/daily-ranking';
 import type { PageLoad } from './$types';
 
@@ -16,14 +17,8 @@ export const prerender = false;
 
 export const load: PageLoad = ({ url }) => {
   const maxDay = maxDayBeforeFinals(POPULATED_SEASONS);
-  const dayParam = url.searchParams.get('day');
-  const parsed = dayParam !== null ? Number(dayParam) : NaN;
   const day =
-    Number.isInteger(parsed) &&
-    parsed >= 0 &&
-    parsed <= maxDay &&
-    String(parsed) === dayParam
-      ? parsed
-      : currentDayUntilFinals(ALL_SEASONS_INCLUDING_SCHEDULED, maxDay);
+    parseCanonicalDay(url.searchParams.get('day'), maxDay) ??
+    currentDayUntilFinals(ALL_SEASONS_INCLUDING_SCHEDULED, maxDay);
   redirect(302, resolve('/daily-ranking/[day]', { day: String(day) }));
 };

--- a/src/routes/daily-ranking/[day]/+page.ts
+++ b/src/routes/daily-ranking/[day]/+page.ts
@@ -1,6 +1,9 @@
 import { error } from '@sveltejs/kit';
 import { POPULATED_SEASONS } from '$data';
-import { maxDayBeforeFinals } from '$lib/utils/daily-ranking';
+import {
+  maxDayBeforeFinals,
+  parseCanonicalDay,
+} from '$lib/utils/daily-ranking';
 import type { EntryGenerator, PageLoad } from './$types';
 
 const MAX_DAY = maxDayBeforeFinals(POPULATED_SEASONS);
@@ -9,15 +12,8 @@ export const entries: EntryGenerator = () =>
   Array.from({ length: MAX_DAY + 1 }, (_, day) => ({ day: String(day) }));
 
 export const load: PageLoad = ({ params }) => {
-  const day = Number(params.day);
-  // Canonical non-negative integers only: rejects "banana", "07", "-1",
-  // "3.5", and anything beyond the earliest first-show day.
-  if (
-    !Number.isInteger(day) ||
-    day < 0 ||
-    day > MAX_DAY ||
-    String(day) !== params.day
-  ) {
+  const day = parseCanonicalDay(params.day, MAX_DAY);
+  if (day === undefined) {
     error(404, `No day ${params.day}`);
   }
   return { day };

--- a/src/routes/tour/+page.ts
+++ b/src/routes/tour/+page.ts
@@ -1,6 +1,7 @@
 import { redirect } from '@sveltejs/kit';
 import { resolve } from '$app/paths';
 import { POPULATED_SEASONS } from '$data';
+import { seasonForYear } from '$lib/utils/tour';
 import type { PageLoad } from './$types';
 
 // This route alone is served dynamically (by the Cloudflare worker in
@@ -9,9 +10,8 @@ import type { PageLoad } from './$types';
 export const prerender = false;
 
 export const load: PageLoad = ({ url }) => {
-  const yearParam = url.searchParams.get('year');
   const target =
-    POPULATED_SEASONS.find((s) => s.year === yearParam) ??
+    seasonForYear(POPULATED_SEASONS, url.searchParams.get('year')) ??
     POPULATED_SEASONS[POPULATED_SEASONS.length - 1];
   redirect(302, resolve('/tour/[year]', { year: target.year }));
 };

--- a/src/routes/tour/[year]/+page.ts
+++ b/src/routes/tour/[year]/+page.ts
@@ -1,12 +1,13 @@
 import { error } from '@sveltejs/kit';
 import { POPULATED_SEASONS } from '$data';
+import { seasonForYear } from '$lib/utils/tour';
 import type { EntryGenerator, PageLoad } from './$types';
 
 export const entries: EntryGenerator = () =>
   POPULATED_SEASONS.map((season) => ({ year: season.year }));
 
 export const load: PageLoad = ({ params }) => {
-  const season = POPULATED_SEASONS.find((s) => s.year === params.year);
+  const season = seasonForYear(POPULATED_SEASONS, params.year);
   if (!season) {
     error(404, `No ${params.year} season`);
   }

--- a/tests/unit/daily-ranking.test.ts
+++ b/tests/unit/daily-ranking.test.ts
@@ -5,6 +5,7 @@ import {
   currentSeasonYear,
   dayRankingLabel,
   maxDayBeforeFinals,
+  parseCanonicalDay,
 } from '../../src/lib/utils/daily-ranking';
 import type { SeasonScores } from '../../src/lib/data/base';
 
@@ -337,5 +338,28 @@ describe('dayRankingLabel', () => {
   it('uses Day N for the rest of the season', () => {
     expect(dayRankingLabel(3)).toBe('Day 3');
     expect(dayRankingLabel(28)).toBe('Day 28');
+  });
+});
+
+describe('parseCanonicalDay', () => {
+  it('accepts canonical integers within range', () => {
+    expect(parseCanonicalDay('0', 64)).toBe(0);
+    expect(parseCanonicalDay('28', 64)).toBe(28);
+    expect(parseCanonicalDay('64', 64)).toBe(64);
+  });
+
+  it('rejects null (absent param)', () => {
+    expect(parseCanonicalDay(null, 64)).toBeUndefined();
+  });
+
+  it('rejects non-numeric, non-canonical, and fractional forms', () => {
+    expect(parseCanonicalDay('banana', 64)).toBeUndefined();
+    expect(parseCanonicalDay('07', 64)).toBeUndefined();
+    expect(parseCanonicalDay('3.5', 64)).toBeUndefined();
+  });
+
+  it('rejects out-of-range integers', () => {
+    expect(parseCanonicalDay('-1', 64)).toBeUndefined();
+    expect(parseCanonicalDay('65', 64)).toBeUndefined();
   });
 });

--- a/tests/unit/tour.test.ts
+++ b/tests/unit/tour.test.ts
@@ -9,6 +9,7 @@ import {
   tourSummary,
   finalsOrLatestScore,
   placementLabel,
+  seasonForYear,
 } from '../../src/lib/utils/tour';
 import type { SeasonScores } from '../../src/lib/data/base';
 
@@ -220,5 +221,16 @@ describe('same-date shows', () => {
   it('builds a tour log with the same row count (no collapsing of shared dates)', () => {
     const log = buildTourLog([...ALL, S_DOUBLEHEADER], S_DOUBLEHEADER);
     expect(log).toHaveLength(3);
+  });
+});
+
+describe('seasonForYear', () => {
+  it('finds a season by exact year string', () => {
+    expect(seasonForYear(ALL, '2024')?.year).toBe('2024');
+  });
+
+  it('returns undefined for unknown years and null', () => {
+    expect(seasonForYear(ALL, '1999')).toBeUndefined();
+    expect(seasonForYear(ALL, null)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Behavior-preserving refactor, closing out a follow-up from #375's review: the canonical-day validation lived in two different shapes across the daily-ranking loads, and the season-by-year lookup was duplicated across the tour loads.

- **`parseCanonicalDay(raw, maxDay)`** in `src/lib/utils/daily-ranking.ts` — returns the day iff the string is the canonical decimal form of an integer in `0..maxDay` (rejects `null`, `banana`, `07`, `-1`, `3.5`). Both `daily-ranking/[day]` (404 path) and the `/daily-ranking` redirect (`?? currentDayUntilFinals(…)` fallback) consume it.
- **`seasonForYear(seasons, year)`** in `src/lib/utils/tour.ts` — membership lookup by exact year string (deliberately not "parseCanonicalYear": years are valid by membership in `POPULATED_SEASONS`, not by numeric shape). Both `tour/[year]` and the `/tour` redirect consume it.
- New unit suites for both helpers (canonical bounds, null/absent, non-canonical forms, unknown years).

No URLs, status codes, copy, `entries()`, or e2e files changed — the existing 404/redirect e2e suites are the regression net.

## Test plan

- [x] Unit 134/134 (6 new tests, RED→GREEN), full e2e 37/37 unchanged, all linters clean (knip accepts both new exports)
- [x] Review traced old-vs-new behavior for the edge inputs (`"07"`, empty-string query params, absent params, day `0` vs the `??` fallback) — identical outcomes in every case

🤖 Generated with [Claude Code](https://claude.com/claude-code)