### PR TITLE
Calendar-proof the two seasonal e2e assertions

### DIFF
--- a/tests/e2e/daily-ranking.test.ts
+++ b/tests/e2e/daily-ranking.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { POPULATED_SEASONS } from '../../src/lib/data';
 
 test('/daily-ranking redirects to the current day', async ({ page }) => {
   await page.goto('/daily-ranking');
@@ -33,8 +34,10 @@ test('day 0 renders every ranked season with the Finals title', async ({
   // calendar date (the same determinism rationale as the old suite).
   await page.goto('/daily-ranking/0');
   await expect(page).toHaveTitle('Finals Ranking | Bluecoats Scores');
+  // One row per populated season — derived from the data so the assertion
+  // stays exact when a new season records its first score.
   const rows = page.locator('tbody tr');
-  await expect(rows).toHaveCount(46);
+  await expect(rows).toHaveCount(POPULATED_SEASONS.length);
 });
 
 test('a day page has its own countdown title', async ({ page }) => {
@@ -44,8 +47,9 @@ test('a day page has its own countdown title', async ({ page }) => {
 
 test('chips navigate between day pages', async ({ page }) => {
   await page.goto('/daily-ranking/10');
-  // Quick-jump chips are real links now.
-  await page.getByRole('link', { name: '45d' }).click();
+  // Locate the chip by href, not label: the label reads "45d" except on the
+  // one day a year when currentDay === 45, when it relabels to "Today".
+  await page.locator('a[href="/daily-ranking/45"]').click();
   await expect(page).toHaveURL(/\/daily-ranking\/45$/);
   await expect(page.getByText(/Day 45 Leaderboard/)).toBeVisible();
 });


### PR DESCRIPTION
## Summary

Closes out the last test-fragility follow-up from #375's review. Two assertions in `tests/e2e/daily-ranking.test.ts` depended on the calendar:

- The chip-navigation test located the 45-day chip by its label (`45d`), which relabels to "Today" on the one day a year when `currentDay === 45` — a guaranteed annual CI failure. It now locates the chip by its stable `href` (`a[href="/daily-ranking/45"]`), with a comment explaining the hazard.
- The day-0 test asserted a hardcoded 46 rows, which bumps every time a new season records its first score. It now asserts `POPULATED_SEASONS.length` (imported directly from the season data), so it stays exact and self-maintains — the import resolves cleanly through Playwright's tsconfig path support, no fallback needed.

Tests-only: no product code changed, no assertions weakened.

## Test plan

- [x] `pnpm test:e2e tests/e2e/daily-ranking.test.ts` — 14/14 on a cold build (data-driven count path)
- [x] `pnpm lint` — all linters green; knip accepts the new test-to-src import

🤖 Generated with [Claude Code](https://claude.com/claude-code)