### PR TITLE
Log Gold Showcase score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -33,6 +33,7 @@ export const SEASON_2026: SeasonScores = {
       date: '2026-07-09',
       location: 'Santa Clarita, CA',
       name: 'Gold Showcase',
+      score: 85.3,
     },
     {
       date: '2026-07-10',


### PR DESCRIPTION
Fills in the 2026-07-09 Gold Showcase (Santa Clarita, CA) result: **85.3**. Lint and unit tests pass (134/134).

🤖 Generated with [Claude Code](https://claude.com/claude-code)