### PR TITLE
Log Western Corps Connection score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -39,6 +39,7 @@ export const SEASON_2026: SeasonScores = {
       date: '2026-07-10',
       location: 'Walnut, CA',
       name: 'Western Corps Connection',
+      score: 86.75,
     },
     {
       date: '2026-07-11',


### PR DESCRIPTION
Western Corps Connection (Walnut, CA, 2026-07-10) scored **86.75**.

`pnpm lint` and `pnpm test:unit` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)