### PR TITLE
Use native page scroll for scroll-to-top on navigation

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="h-full overflow-hidden bg-white">
+<html lang="en" class="h-full bg-white">
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%sveltekit.assets%/favicon.svg" />
@@ -7,10 +7,7 @@
     <link rel="stylesheet" href="https://rsms.me/inter/inter.css" />
     %sveltekit.head%
   </head>
-  <body
-    data-sveltekit-preload-data="hover"
-    class="h-full overflow-hidden font-sans"
-  >
+  <body data-sveltekit-preload-data="hover" class="min-h-full font-sans">
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/src/lib/components/nav/MobileTabBar.svelte
+++ b/src/lib/components/nav/MobileTabBar.svelte
@@ -15,7 +15,7 @@
 </script>
 
 <nav
-  class="absolute inset-x-0 bottom-0 z-20 grid grid-cols-4 border-t border-gray-200 bg-white/90 px-1 pt-1.5 pb-[calc(0.625rem+env(safe-area-inset-bottom,0))] backdrop-blur-lg backdrop-saturate-150 md:hidden"
+  class="fixed inset-x-0 bottom-0 z-20 grid grid-cols-4 border-t border-gray-200 bg-white/90 px-1 pt-1.5 pb-[calc(0.625rem+env(safe-area-inset-bottom,0))] backdrop-blur-lg backdrop-saturate-150 md:hidden"
   aria-label="Primary"
 >
   {#each NAV_ITEMS as item (item.href)}

--- a/src/lib/components/nav/NavigationBar.svelte
+++ b/src/lib/components/nav/NavigationBar.svelte
@@ -8,7 +8,7 @@
 </script>
 
 <header
-  class="bg-navy-900 border-b border-white/5 pt-[env(safe-area-inset-top,0)] text-white"
+  class="bg-navy-900 sticky top-0 z-30 border-b border-white/5 pt-[env(safe-area-inset-top,0)] text-white"
 >
   <div
     class="mx-auto flex max-w-300 items-center gap-4 px-4 py-3 md:gap-7 md:px-6 md:py-3.5"

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -12,11 +12,9 @@
   <title>Bluecoats Scores</title>
 </svelte:head>
 
-<div class="relative flex h-full flex-col">
+<div class="flex min-h-full flex-col">
   <NavigationBar />
-  <main
-    class="flex-1 overflow-y-auto overscroll-contain pb-[calc(4rem+env(safe-area-inset-bottom,0))] md:pb-0"
-  >
+  <main class="flex-1 pb-[calc(4rem+env(safe-area-inset-bottom,0))] md:pb-0">
     {@render children()}
     <Footer />
   </main>

--- a/tests/e2e/page-scroll.test.ts
+++ b/tests/e2e/page-scroll.test.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+
+test('the window scrolls and navigation resets to the top', async ({
+  page,
+}) => {
+  // Score History is a tall page (the chart alone is 50rem), so the
+  // document overflows the viewport and the window can scroll.
+  await page.goto('/score-history');
+  await expect(
+    page.getByRole('heading', { name: 'Score History' }),
+  ).toBeVisible();
+
+  // Scrolling the WINDOW must actually move the page. With the old custom
+  // scroll container, <html>/<body> were overflow-hidden, so window.scrollY
+  // stayed 0 and this assertion failed.
+  await page.evaluate(() => window.scrollTo(0, 600));
+  await expect
+    .poll(() => page.evaluate(() => window.scrollY))
+    .toBeGreaterThan(0);
+
+  // Client-side navigation should land at the top of the new page.
+  await page.getByRole('link', { name: 'Today' }).click();
+  await expect(page).toHaveURL(/\/$/);
+  await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(0);
+});
+
+test('the header stays pinned to the top while the page scrolls', async ({
+  page,
+}) => {
+  await page.goto('/score-history');
+  const header = page.getByRole('banner');
+  await expect(header).toBeVisible();
+
+  await page.evaluate(() => window.scrollTo(0, 600));
+  await expect
+    .poll(() => page.evaluate(() => window.scrollY))
+    .toBeGreaterThan(0);
+
+  // A sticky header keeps its top edge at the top of the viewport.
+  const box = await header.boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.y).toBeLessThanOrEqual(1);
+});


### PR DESCRIPTION
## Why

Navigating between pages (especially on mobile) often left the user partway down the new page instead of at the top. SvelteKit's built-in scroll handling — scroll-to-top on forward navigation and position restoration on back/forward — only acts on the **window/document**. This app never let the window scroll (`<html>`/`<body>` were `overflow-hidden`) and did all scrolling inside a custom `<main class="overflow-y-auto">` container, so SvelteKit had nothing to reset.

## What

Move scrolling to the native document/window so that behavior works for free, while keeping the header pinned to the top and the mobile tab bar pinned to the bottom. Purely CSS/structure — no new JavaScript, no scroll listeners, no navigation hooks.

- `src/app.html` — drop `overflow-hidden` from `<html>`/`<body>`; `<body>` becomes `min-h-full` so it grows with content.
- `src/routes/+layout.svelte` — wrapper becomes `flex min-h-full flex-col` (drops the now-unneeded `relative`); `<main>` drops `overflow-y-auto overscroll-contain` (keeps `flex-1` and the bottom padding that clears the fixed tab bar).
- `src/lib/components/nav/NavigationBar.svelte` — header gains `sticky top-0 z-30`.
- `src/lib/components/nav/MobileTabBar.svelte` — `absolute` → `fixed` so it pins to the viewport bottom under page scroll.

## Testing

- New Playwright regression test `tests/e2e/page-scroll.test.ts`: verifies the window actually scrolls (`window.scrollY > 0` after `scrollTo` — fails on the old container-scroll code), that client-side navigation resets to the top, and that the header stays pinned while scrolled.
- Full suite green: e2e **39 passed** (was 37), unit suite passing, `pnpm lint` + `pnpm build` clean.
- Manually verified in Chrome at a mobile viewport (393×852): scroll-to-top on nav, header/tab-bar pinned while scrolled, and browser-back scroll restoration.

## Tradeoff

On iOS the Safari URL bar now hides/shows on scroll (native behavior) — the expected cost of moving to native page scroll.

## Notes (non-blocking, from review)

- `page-scroll.test.ts` duplicates the `goto + scrollTo + scrollY` setup across its two tests; the header-pin test shares the first test's `scrollY`-precondition, so its sticky assertion is only exercised in the GREEN run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)