### PR TITLE
Log Drum Corps at the Rose Bowl score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -45,6 +45,7 @@ export const SEASON_2026: SeasonScores = {
       date: '2026-07-11',
       location: 'Pasadena, CA',
       name: 'Drum Corps at the Rose Bowl',
+      score: 87.575,
     },
     {
       date: '2026-07-13',


### PR DESCRIPTION
Logs the Bluecoats' score of **87.575** at Drum Corps at the Rose Bowl (2026-07-11, Pasadena, CA).

`pnpm lint` and `pnpm test:unit` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)