### PR TITLE
a11y: fix caption text contrast (gray-400 → gray-500)

### DIFF
--- a/src/lib/components/daily-ranking/Table.svelte
+++ b/src/lib/components/daily-ranking/Table.svelte
@@ -123,7 +123,7 @@
             {ranking.score.toFixed(3)}
           </div>
           {#if ranking.daysOld}
-            <div class="mt-0.5 text-xs whitespace-nowrap text-gray-400">
+            <div class="mt-0.5 text-xs whitespace-nowrap text-gray-500">
               {ranking.daysOld}
               {ranking.daysOld === 1 ? 'day' : 'days'} prior
             </div>

--- a/src/lib/components/today/ClosestSeasons.svelte
+++ b/src/lib/components/today/ClosestSeasons.svelte
@@ -114,7 +114,7 @@
           </div>
           {#if item.daysOld}
             <div
-              class="mt-0.5 text-xs font-normal whitespace-nowrap text-gray-400"
+              class="mt-0.5 text-xs font-normal whitespace-nowrap text-gray-500"
             >
               {item.daysOld}
               {item.daysOld === 1 ? 'day' : 'days'} prior

--- a/src/lib/components/tour/SeasonPicker.svelte
+++ b/src/lib/components/tour/SeasonPicker.svelte
@@ -83,7 +83,7 @@
         fill="none"
         stroke="currentColor"
         stroke-width="2.5"
-        class="pointer-events-none absolute top-1/2 right-3 size-3 -translate-y-1/2 text-gray-400"
+        class="pointer-events-none absolute top-1/2 right-3 size-3 -translate-y-1/2 text-gray-500"
         aria-hidden="true"><path d="M6 9l6 6 6-6" /></svg
       >
     </div>

--- a/src/lib/components/tour/TourLog.svelte
+++ b/src/lib/components/tour/TourLog.svelte
@@ -52,7 +52,7 @@
           {formatDate(row.date)}
         </td>
         <td
-          class="hidden px-3 py-3 align-middle text-sm whitespace-nowrap text-gray-400 tabular-nums lg:table-cell"
+          class="hidden px-3 py-3 align-middle text-sm whitespace-nowrap text-gray-500 tabular-nums lg:table-cell"
         >
           {row.daysBeforeFinals}d
         </td>
@@ -61,7 +61,7 @@
             {row.name ?? row.location}
           </div>
           {#if row.name}
-            <div class="text-xs text-gray-400">{row.location}</div>
+            <div class="text-xs text-gray-500">{row.location}</div>
           {/if}
         </td>
         <td
@@ -109,7 +109,7 @@
           {#if row.rankThen !== null && row.rankNow !== null}
             {@const delta = row.rankNow - row.rankThen}
             {#if delta === 0}
-              <span class="text-xs text-gray-400">holds</span>
+              <span class="text-xs text-gray-500">holds</span>
             {:else}
               <span
                 aria-label={delta > 0

--- a/src/lib/components/tour/TourStats.svelte
+++ b/src/lib/components/tour/TourStats.svelte
@@ -14,7 +14,7 @@
     <div class="mt-1 text-2xl font-semibold tabular-nums text-gray-900">
       {summary.seasonHigh !== null ? summary.seasonHigh.toFixed(3) : '—'}
     </div>
-    <div class="mt-0.5 text-xs text-gray-400">
+    <div class="mt-0.5 text-xs text-gray-500">
       {inProgress
         ? 'so far'
         : summary.finalsRank !== null
@@ -31,7 +31,7 @@
         ? `${summary.climb >= 0 ? '+' : ''}${summary.climb.toFixed(2)}`
         : '—'}
     </div>
-    <div class="mt-0.5 text-xs text-gray-400">first to latest score</div>
+    <div class="mt-0.5 text-xs text-gray-500">first to latest score</div>
   </Card>
   <Card>
     <div class="text-xs font-medium tracking-wide text-gray-500 uppercase">
@@ -40,7 +40,7 @@
     <div class="mt-1 text-2xl font-semibold tabular-nums text-gray-900">
       {summary.topFiveDays}
     </div>
-    <div class="mt-0.5 text-xs text-gray-400">shows ranked top 5 all-time</div>
+    <div class="mt-0.5 text-xs text-gray-500">shows ranked top 5 all-time</div>
   </Card>
   <Card>
     <div class="text-xs font-medium tracking-wide text-gray-500 uppercase">
@@ -49,6 +49,6 @@
     <div class="mt-1 text-2xl font-semibold tabular-nums text-gray-900">
       {summary.allTimeBestDays}
     </div>
-    <div class="mt-0.5 text-xs text-gray-400">scores still #1 today</div>
+    <div class="mt-0.5 text-xs text-gray-500">scores still #1 today</div>
   </Card>
 </div>


### PR DESCRIPTION
## Problem

`text-gray-400` resolves to `#99a1af`, which is only **2.60:1** against the white table/card background — below the WCAG AA minimum of 4.5:1 for normal text (these captions are 12px). Spotted first on the daily-ranking table's "N days prior" label, but it's the same token used across several caption/secondary-text spots.

## Fix

Move every failing instance from `gray-400` → `gray-500` (`#6a7282`, **4.84:1** — passes AA). `gray-500` is already the established "secondary text" tier in these same components, so the visual hierarchy is preserved while clearing contrast.

Affected (10 spots, 5 files):
- `daily-ranking/Table.svelte` — "N days prior"
- `tour/TourStats.svelte` ×4 — stat captions
- `tour/TourLog.svelte` ×3 — location, date cell, "holds" label
- `today/ClosestSeasons.svelte` — caption
- `tour/SeasonPicker.svelte` — dropdown chevron icon (meets the 3:1 non-text contrast guideline)

## Verification

- Computed contrast: gray-400 = 2.60:1 (fail) → gray-500 = 4.84:1 (pass AA).
- `pnpm lint` clean (eslint, svelte-check, stylelint, prettier, knip).
- Diff is 10 pure utility-class swaps, no logic change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)