### PR TITLE
a11y: fix inactive season-strip link contrast

### DIFF
--- a/src/lib/components/tour/SeasonPicker.svelte
+++ b/src/lib/components/tour/SeasonPicker.svelte
@@ -130,7 +130,7 @@
           ? 'bg-brand-600 text-white'
           : champ
             ? 'bg-gold-100 text-gold-700 hover:bg-gold-400/30'
-            : 'bg-gray-100 text-gray-500 hover:bg-gray-200'}"
+            : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}"
         aria-label="{season.year} season"
         aria-current={active ? 'page' : undefined}
       >


### PR DESCRIPTION
## Problem

Lighthouse flags the two-digit year links in the Tour page's season-strip (`SeasonPicker.svelte`) for insufficient contrast.

## Diagnosis

The strip has three link states; only the default one fails:

| State | Colors | Ratio | |
|---|---|---|---|
| Active | white on `brand-600` | 5.86:1 | ✅ |
| Champion | `gold-700` on `gold-100` | 5.59:1 | ✅ |
| **Default (inactive)** | **`gray-500` on `gray-100`** | **4.39:1** | ❌ |
| Default (hover) | `gray-500` on `gray-200` | 3.91:1 | ❌ |

`gray-500` passes AA on white (4.84:1) but the `gray-100` chip background drops it just under the 4.5:1 minimum.

## Fix

Bump the inactive state to `text-gray-700`: **9.37:1** on `gray-100`, **8.33:1** on the `gray-200` hover. `gray-700` is already the color of the prev/next year links in this same component, so it's the consistent choice. Active and champion states are unchanged.

## Verification

- Contrast computed from the actual Tailwind/theme tokens (this is exactly what Lighthouse's audit measures): 4.39:1 → 9.37:1.
- `pnpm lint` clean (eslint, svelte-check, stylelint, prettier, knip). One-line class change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)