### PR TITLE
Log Drums Across the Desert (Mesa) as non-scored for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -51,6 +51,7 @@ export const SEASON_2026: SeasonScores = {
       date: '2026-07-13',
       location: 'Mesa, AZ',
       name: 'Drums Across the Desert',
+      score: null,
     },
     { date: '2026-07-14', location: 'Albuquerque, NM', name: 'DCI New Mexico' },
     { date: '2026-07-16', location: 'Denton, TX', name: 'DCI Denton' },


### PR DESCRIPTION
Records the **Drums Across the Desert** show (Mesa, AZ · 2026-07-13) as `score: null` — the event was rained out, so it produced no comparable score.

Per the data conventions, `null` records that the event happened without making the season appear "populated": it's filtered out of the chart, season select, and daily rankings (only numeric scores surface there).

Verification: `pnpm lint` and `pnpm test:unit` (145 tests) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01F295UjXYdKgduZ5uxgH6z6)_