### PR TITLE
Log DCI New Mexico score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -53,7 +53,12 @@ export const SEASON_2026: SeasonScores = {
       name: 'Drums Across the Desert',
       score: null,
     },
-    { date: '2026-07-14', location: 'Albuquerque, NM', name: 'DCI New Mexico' },
+    {
+      date: '2026-07-14',
+      location: 'Albuquerque, NM',
+      name: 'DCI New Mexico',
+      score: 89.3,
+    },
     { date: '2026-07-16', location: 'Denton, TX', name: 'DCI Denton' },
     { date: '2026-07-17', location: 'Houston, TX', name: 'DCI Houston' },
     {


### PR DESCRIPTION
Records the Bluecoats' result at **DCI New Mexico** (Albuquerque, NM — 2026-07-14): **89.3**.

Fills the `score` on the existing scheduled entry in `src/lib/data/seasons/2026.ts`; no other entries changed.

- `pnpm lint` ✅
- `pnpm test:unit` ✅ (145 passed)

---
_Generated by [Claude Code](https://claude.ai/code/session_016TARgYzVihoTVKcV5HzvFR)_