### PR TITLE
Log DCI Denton score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -59,7 +59,12 @@ export const SEASON_2026: SeasonScores = {
       name: 'DCI New Mexico',
       score: 89.3,
     },
-    { date: '2026-07-16', location: 'Denton, TX', name: 'DCI Denton' },
+    {
+      date: '2026-07-16',
+      location: 'Denton, TX',
+      name: 'DCI Denton',
+      score: 90.4,
+    },
     { date: '2026-07-17', location: 'Houston, TX', name: 'DCI Houston' },
     {
       date: '2026-07-18',


### PR DESCRIPTION
Records the DCI Denton (Denton, TX — 2026-07-16) result as **90.4** on the 2026 season data.

- Filled `score: 90.4` into the existing scheduled `DCI Denton` entry in `src/lib/data/seasons/2026.ts`; no other entries touched.
- `pnpm lint` ✅ and `pnpm test:unit` ✅ (145 tests passing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrkMdbA2eC6xyr52qwCWGP)_