### PR TITLE
Log DCI Houston score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -65,7 +65,12 @@ export const SEASON_2026: SeasonScores = {
       name: 'DCI Denton',
       score: 90.4,
     },
-    { date: '2026-07-17', location: 'Houston, TX', name: 'DCI Houston' },
+    {
+      date: '2026-07-17',
+      location: 'Houston, TX',
+      name: 'DCI Houston',
+      score: 91.15,
+    },
     {
       date: '2026-07-18',
       location: 'San Antonio, TX',


### PR DESCRIPTION
Records the DCI Houston (Houston, TX — 2026-07-17) result as **91.15** on the 2026 season data.

- Filled `score: 91.15` into the existing scheduled `DCI Houston` entry in `src/lib/data/seasons/2026.ts`; no other entries touched.
- `pnpm lint` ✅ and `pnpm test:unit` ✅ (145 tests passing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NrkMdbA2eC6xyr52qwCWGP)_