### PR TITLE
Log DCI Southwestern Championship score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -75,6 +75,7 @@ export const SEASON_2026: SeasonScores = {
       date: '2026-07-18',
       location: 'San Antonio, TX',
       name: 'DCI Southwestern Championship',
+      score: 93.05,
     },
     { date: '2026-07-24', location: 'Nashville, TN', name: 'DCI Nashville' },
     {


### PR DESCRIPTION
Logs the Bluecoats' score of **93.05** at the DCI Southwestern Championship (San Antonio, TX — 2026-07-18) in the 2026 season data.

`pnpm lint` and `pnpm test:unit` (145 tests) both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)