### PR TITLE
Log DCI Middle Tennessee score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -81,6 +81,7 @@ export const SEASON_2026: SeasonScores = {
       date: '2026-07-24',
       location: 'Murfreesboro, TN',
       name: 'DCI Middle Tennessee',
+      score: 94.3,
     },
     {
       date: '2026-07-25',


### PR DESCRIPTION
Records the Bluecoats' 94.3 at DCI Middle Tennessee (Murfreesboro, TN — 2026-07-24).

`pnpm lint` and `pnpm test:unit` both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)