### PR TITLE
Log DCI Southeastern Championship score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -87,6 +87,7 @@ export const SEASON_2026: SeasonScores = {
       date: '2026-07-25',
       location: 'Atlanta, GA',
       name: 'DCI Southeastern Championship',
+      score: 94.725,
     },
     { date: '2026-07-26', location: 'Winston-Salem, NC', name: 'NightBEAT' },
     {


### PR DESCRIPTION
Logs the Bluecoats' score of **94.725** at the DCI Southeastern Championship (Atlanta, GA — 2026-07-25).

`pnpm lint` and `pnpm test:unit` both pass (145/145 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)