### PR TITLE
Log NightBEAT score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -89,7 +89,12 @@ export const SEASON_2026: SeasonScores = {
       name: 'DCI Southeastern Championship',
       score: 94.725,
     },
-    { date: '2026-07-26', location: 'Winston-Salem, NC', name: 'NightBEAT' },
+    {
+      date: '2026-07-26',
+      location: 'Winston-Salem, NC',
+      name: 'NightBEAT',
+      score: 94.85,
+    },
     {
       date: '2026-07-30',
       location: 'Lawrence, MA',


### PR DESCRIPTION
Fills in the score for NightBEAT (2026-07-26, Winston-Salem, NC) as **94.85** on the existing scheduled entry in `src/lib/data/seasons/2026.ts`.

`pnpm lint` passes (all five linters) and `pnpm test:unit` passes (145 tests, 11 files).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjVEqYviizoqZs133WDE7v)_