### PR TITLE
Log DCI East Coast Showcase score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -99,6 +99,7 @@ export const SEASON_2026: SeasonScores = {
       date: '2026-07-30',
       location: 'Lawrence, MA',
       name: 'DCI East Coast Showcase',
+      score: 96.25,
     },
     {
       date: '2026-07-31',


### PR DESCRIPTION
Records the 2026-07-30 DCI East Coast Showcase (Lawrence, MA) result: **96.25**.

`pnpm lint` and `pnpm test:unit` both pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)