### PR TITLE
Log DCI Eastern Classic score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -105,6 +105,7 @@ export const SEASON_2026: SeasonScores = {
       date: '2026-07-31',
       location: 'Allentown, PA',
       name: 'DCI Eastern Classic',
+      score: 96.825,
     },
     { date: '2026-08-03', location: 'Akron, OH', name: 'Innovations in Brass' },
     {


### PR DESCRIPTION
Logs the Bluecoats' score of **96.825** at the DCI Eastern Classic (Allentown, PA) on 2026-07-31.

`pnpm lint` and `pnpm test:unit` both pass locally (145 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)