### PR TITLE
Log Innovations in Brass score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -107,7 +107,12 @@ export const SEASON_2026: SeasonScores = {
       name: 'DCI Eastern Classic',
       score: 96.825,
     },
-    { date: '2026-08-03', location: 'Akron, OH', name: 'Innovations in Brass' },
+    {
+      date: '2026-08-03',
+      location: 'Akron, OH',
+      name: 'Innovations in Brass',
+      score: 97.45,
+    },
     {
       date: '2026-08-06',
       location: 'Indianapolis, IN',


### PR DESCRIPTION
Records the Bluecoats' result at Innovations in Brass (Akron, OH — 2026-08-03): **97.45**.

Fills the `score` field on the existing scheduled entry in `src/lib/data/seasons/2026.ts`; no other entries touched, so date ordering is preserved. Not a Finals event, so `placement` is unchanged.

Verification: `pnpm lint` passes (js, css, types, format, knip) and `pnpm test:unit` passes 145/145.

---
_Generated by [Claude Code](https://claude.ai/code/session_01W69YW2mHpAomNvQ2u3WTYa)_