### PR TITLE
Log DCI World Championship Prelims score for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -117,6 +117,7 @@ export const SEASON_2026: SeasonScores = {
       date: '2026-08-06',
       location: 'Indianapolis, IN',
       name: 'DCI World Championship Prelims',
+      score: 98.3,
     },
     {
       date: '2026-08-07',


### PR DESCRIPTION
Bluecoats scored **98.3** at DCI World Championship Prelims in Indianapolis, IN on 2026-08-06.

Fills the `score` field on the existing scheduled entry in `src/lib/data/seasons/2026.ts` — one line, no other entries touched.

Verified locally: `pnpm lint` passes all five checks (js, css, types, format, knip); `pnpm test:unit` passes 145/145.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgjvV9tztuowCDVoec3w3Y)_