### PR TITLE
Log DCI World Championship Finals score and placement for 2026

### DIFF
--- a/src/lib/data/seasons/2026.ts
+++ b/src/lib/data/seasons/2026.ts
@@ -3,6 +3,7 @@ import { type SeasonScores } from '$data/base';
 export const SEASON_2026: SeasonScores = {
   year: '2026',
   endDate: '2026-08-08',
+  placement: 1,
   show: 'Gravity & Grace',
   scores: [
     {
@@ -129,6 +130,7 @@ export const SEASON_2026: SeasonScores = {
       date: '2026-08-08',
       location: 'Indianapolis, IN',
       name: 'DCI World Championship Finals',
+      score: 99.1,
     },
   ],
 };


### PR DESCRIPTION
Bluecoats scored **99.1** at DCI World Championship Finals in Indianapolis, IN on 2026-08-08, finishing **1st**. 🏆

Two changes in `src/lib/data/seasons/2026.ts`:

- `score: 99.1` on the existing Finals entry (2026-08-08)
- `placement: 1` on the `SEASON_2026` object, positioned after `endDate` to match the 2019/2022/2023/2024/2025 convention

This is the final event of the 2026 season (`endDate: '2026-08-08'`), so the season is now complete.

Verified locally: `pnpm lint` passes all five checks (js, css, types, format, knip); `pnpm test:unit` passes 145/145.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgjvV9tztuowCDVoec3w3Y)_