### PR TITLE
Paint the featured season gold once it places 1st

### DIFF
--- a/src/lib/components/score-history/ChartLegend.svelte
+++ b/src/lib/components/score-history/ChartLegend.svelte
@@ -1,16 +1,30 @@
 <script lang="ts">
-  let { featuredYear }: { featuredYear?: string } = $props();
+  let {
+    featuredYear,
+    featuredIsChampion = false,
+  }: { featuredYear?: string; featuredIsChampion?: boolean } = $props();
 </script>
 
 <div class="flex items-center gap-3.5 text-xs text-gray-500">
-  <span class="inline-flex items-center gap-1.5">
-    <span class="bg-brand-600 inline-block h-0.5 w-3.5"></span>
-    {featuredYear ?? 'Latest'}
-  </span>
-  <span class="inline-flex items-center gap-1.5">
-    <span class="bg-gold-500 inline-block h-0.5 w-3.5"></span>
-    Champion
-  </span>
+  {#if featuredIsChampion}
+    <!--
+      The featured line is gold because that season won, so it collapses into
+      the Champion entry rather than showing two identical gold swatches.
+    -->
+    <span class="inline-flex items-center gap-1.5">
+      <span class="bg-gold-500 inline-block h-0.5 w-3.5"></span>
+      {featuredYear ?? 'Latest'} · Champion
+    </span>
+  {:else}
+    <span class="inline-flex items-center gap-1.5">
+      <span class="bg-brand-600 inline-block h-0.5 w-3.5"></span>
+      {featuredYear ?? 'Latest'}
+    </span>
+    <span class="inline-flex items-center gap-1.5">
+      <span class="bg-gold-500 inline-block h-0.5 w-3.5"></span>
+      Champion
+    </span>
+  {/if}
   <span class="inline-flex items-center gap-1.5">
     <span class="bg-navy-900 inline-block h-0.5 w-3.5"></span>
     Compare

--- a/src/lib/utils/chart-options.ts
+++ b/src/lib/utils/chart-options.ts
@@ -163,7 +163,12 @@ function seriesForSeason(
     };
   }
 
-  // featured protagonist
+  // Featured protagonist. A featured season that won its championship keeps the
+  // protagonist's weight, symbols and marker but wears the gold palette, so the
+  // title reads at a glance instead of looking like any other current season.
+  const isChampion = season.placement === 1;
+  const featuredColor = isChampion ? COLOR_CHAMPION : COLOR_FEATURED;
+  const featuredLabelColor = isChampion ? COLOR_CHAMPION_INK : COLOR_FEATURED;
   const latest = scoredEntries(season).at(-1);
   const markPoint =
     inProgress && latest
@@ -171,7 +176,7 @@ function seriesForSeason(
           symbol: 'circle',
           symbolSize: 12,
           itemStyle: {
-            color: COLOR_FEATURED,
+            color: featuredColor,
             borderColor: '#fff',
             borderWidth: 3,
           },
@@ -203,12 +208,12 @@ function seriesForSeason(
     z: 100,
     symbol: 'circle',
     symbolSize: 6,
-    lineStyle: { color: COLOR_FEATURED, width: 3.25, opacity: 1 },
-    itemStyle: { color: COLOR_FEATURED, borderColor: '#fff', borderWidth: 2 },
+    lineStyle: { color: featuredColor, width: 3.25, opacity: 1 },
+    itemStyle: { color: featuredColor, borderColor: '#fff', borderWidth: 2 },
     endLabel: {
       show: true,
       formatter: season.year,
-      color: COLOR_FEATURED,
+      color: featuredLabelColor,
       fontWeight: 'bold',
       fontSize: 13,
     },

--- a/src/routes/score-history/+page.svelte
+++ b/src/routes/score-history/+page.svelte
@@ -18,6 +18,8 @@
   const featured = getFeaturedSeason(POPULATED_SEASONS);
   const featuredYear = featured?.season.year;
   const featuredInProgress = featured?.inProgress ?? false;
+  // A featured season that placed 1st is drawn in gold rather than brand blue.
+  const featuredIsChampion = featured?.season.placement === 1;
 
   const yearsParam = $derived(
     browser ? page.url.searchParams.get('years') : null,
@@ -70,7 +72,7 @@
             Hover any line to surface it · gold marks championship seasons
           </div>
         </div>
-        <ChartLegend {featuredYear} />
+        <ChartLegend {featuredYear} {featuredIsChampion} />
       </div>
       <div class="flex h-200 flex-col overflow-x-auto px-2 pt-2">
         <SeasonScoresChart

--- a/tests/unit/chart-options.test.ts
+++ b/tests/unit/chart-options.test.ts
@@ -51,6 +51,7 @@ type Series = {
   endLabel?: { show?: boolean };
   markPoint?: {
     label?: { formatter?: string };
+    itemStyle?: { color?: string };
     data: Array<{ coord: [number, number]; name?: string }>;
   };
 };
@@ -153,6 +154,46 @@ describe('buildChartOption', () => {
     });
     expect(seriesByName(opt, '2024').lineStyle?.color).toBe(COLOR_CHAMPION);
     expect(seriesByName(opt, '2024').endLabel?.show).toBe(true);
+  });
+
+  it('paints the featured season gold once it places 1st, keeping protagonist weight', () => {
+    const champion: SeasonScores = { ...SEASON_2025, placement: 1 };
+    const opt = buildChartOption({
+      seasons: [SEASON_2023, SEASON_2024, champion],
+      selectedYears: [],
+      featuredYear: '2025',
+    });
+    const featured = seriesByName(opt, '2025');
+    expect(featured.lineStyle?.color).toBe(COLOR_CHAMPION);
+    expect(featured.itemStyle?.color).toBe(COLOR_CHAMPION);
+    // still the protagonist: heaviest line, symbols, and on top of everything
+    expect(featured.lineStyle?.width).toBe(3.25);
+    expect(featured.symbol).toBe('circle');
+    const others = (opt.series as Series[]).filter((s) => s.name !== '2025');
+    for (const s of others) expect(featured.z ?? 0).toBeGreaterThan(s.z ?? 0);
+  });
+
+  it('keeps the featured season blue while its placement is still unset', () => {
+    const inProgress: SeasonScores = { ...SEASON_2025, placement: undefined };
+    const opt = buildChartOption({
+      seasons: [inProgress],
+      selectedYears: [],
+      featuredYear: '2025',
+    });
+    expect(seriesByName(opt, '2025').lineStyle?.color).toBe(COLOR_FEATURED);
+  });
+
+  it('golds the featured marker so it matches the line it pins to', () => {
+    const champion: SeasonScores = { ...SEASON_2025, placement: 1 };
+    const opt = buildChartOption({
+      seasons: [champion],
+      selectedYears: [],
+      featuredYear: '2025',
+      featuredInProgress: true,
+    });
+    expect(seriesByName(opt, '2025').markPoint?.itemStyle?.color).toBe(
+      COLOR_CHAMPION,
+    );
   });
 
   it('renders ordinary unselected seasons as faint gray hairlines', () => {


### PR DESCRIPTION
2026 stayed brand blue on the Score History chart after winning, because `roleFor` in `chart-options.ts` checks `featured` before `champion` — the protagonist season never reaches the gold `champion` branch.

## Changes

**`chart-options.ts`** — the featured branch now selects the gold palette when `placement === 1`, while keeping everything that makes it the protagonist: 3.25px line, circle symbols, end label, `z: 100`, and the Today marker. The end label uses `COLOR_CHAMPION_INK` (`#7a5a1d`) rather than the lighter gold, so the year stays legible on white.

**`ChartLegend.svelte`** — the featured swatch was hardcoded `bg-brand-600`, so it would have shown blue next to a gold line. When the featured season is a champion, the entry collapses into one gold `<year> · Champion` swatch. Keeping both entries would have shown two identical gold swatches; dropping the Champion entry would have left the older gold hairlines (2024, 2019, …) unexplained.

**`score-history/+page.svelte`** — passes `featuredIsChampion` through.

## Verification

`pnpm lint` passes all five checks; `pnpm test:unit` passes 148/148, including three new cases: featured + `placement: 1` renders gold and keeps protagonist weight, featured stays blue while placement is unset, and the marker matches its line.

Also checked against the real committed 2026 data — featured resolves to 2026, `placement: 1`, line color `#c79a3a`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NgjvV9tztuowCDVoec3w3Y)_