### PR TITLE
Add stub for the 2027 season

### DIFF
--- a/src/lib/data/index.ts
+++ b/src/lib/data/index.ts
@@ -46,6 +46,7 @@ import { SEASON_2023 } from './seasons/2023';
 import { SEASON_2024 } from './seasons/2024';
 import { SEASON_2025 } from './seasons/2025';
 import { SEASON_2026 } from './seasons/2026';
+import { SEASON_2027 } from './seasons/2027';
 
 /**
  * Every known season, including upcoming ones whose `scores` array is empty
@@ -102,6 +103,7 @@ export const ALL_SEASONS_INCLUDING_SCHEDULED: SeasonScores[] = [
   SEASON_2024,
   SEASON_2025,
   SEASON_2026,
+  SEASON_2027,
 ];
 
 /**

--- a/src/lib/data/seasons/2027.ts
+++ b/src/lib/data/seasons/2027.ts
@@ -1,0 +1,7 @@
+import { type SeasonScores } from '$data/base';
+
+export const SEASON_2027: SeasonScores = {
+  year: '2027',
+  endDate: '2027-08-14',
+  scores: [],
+};


### PR DESCRIPTION
Registers an empty 2027 season with its Finals date (August 14) so the days-to-finals countdown has a future target now that the 2026 season is complete — without an upcoming season, `nextFinalsSeason` finds nothing and `daysToFinals` returns 0.

With no scored entries, 2027 is filtered out of `POPULATED_SEASONS`, so it stays out of the chart, season select, `/tour/[year]` pages, and daily rankings until results start landing. Mirrors how the 2026 stub was introduced in #259.

Schedule entries to follow once the 2027 tour is announced.

## Verification

Rebased onto `main` at #443, so it sits on top of the complete 2026 season data.

- `pnpm lint` — clean (eslint, stylelint, prettier, svelte-check, knip)
- `pnpm test` — 148 unit tests, 44 E2E tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)