### PR TITLE
End the featured season's "in progress" state once a placement is set

### DIFF
--- a/src/lib/utils/featured-season.ts
+++ b/src/lib/utils/featured-season.ts
@@ -6,8 +6,9 @@ export interface FeaturedSeason {
   /** The season to highlight as the chart's protagonist. */
   season: SeasonScores;
   /**
-   * True while the season's Finals are still ahead — i.e. a tour is underway.
-   * The chart pins a "Today" marker to the latest result only in this case.
+   * True while a tour is underway: the season's Finals are still ahead *and* no
+   * final placement has been recorded yet. The chart pins a "Today" marker to
+   * the latest result only in this case.
    */
   inProgress: boolean;
 }
@@ -28,8 +29,12 @@ export function getFeaturedSeason(
     candidate.year > latest.year ? candidate : latest,
   );
 
+  // Finals night runs late: the season's end date is still "today" for hours
+  // after the placement is announced, so a recorded placement — not the
+  // calendar alone — is what ends the season.
   const finalsDate = DateTime.fromISO(season.endDate, { zone: FINALS_ZONE });
-  const inProgress = finalsDate >= now.startOf('day');
+  const inProgress =
+    season.placement == null && finalsDate >= now.startOf('day');
 
   return { season, inProgress };
 }

--- a/tests/unit/featured-season.test.ts
+++ b/tests/unit/featured-season.test.ts
@@ -34,6 +34,17 @@ const SEASON_2026_LIVE: SeasonScores = {
   scores: [{ date: '2026-06-27', location: 'Alliance, OH', score: 74.5 }],
 };
 
+// The same 2026 season after Finals night, once the result is logged.
+const SEASON_2026_PLACED: SeasonScores = {
+  year: '2026',
+  endDate: '2026-08-08',
+  placement: 1,
+  scores: [
+    { date: '2026-06-27', location: 'Alliance, OH', score: 74.5 },
+    { date: '2026-08-08', location: 'Indianapolis, IN', score: 99.1 },
+  ],
+};
+
 describe('getFeaturedSeason', () => {
   it('returns undefined when there are no populated seasons', () => {
     expect(getFeaturedSeason([])).toBeUndefined();
@@ -73,5 +84,29 @@ describe('getFeaturedSeason', () => {
     );
     expect(featured?.season.year).toBe('2026');
     expect(featured?.inProgress).toBe(true);
+  });
+
+  it('keeps the season in progress on Finals day before a placement is set', () => {
+    const now = DateTime.fromISO('2026-08-08T14:00', {
+      zone: 'America/New_York',
+    });
+    const featured = getFeaturedSeason(
+      [SEASON_2024, SEASON_2025, SEASON_2026_LIVE],
+      now,
+    );
+    expect(featured?.season.year).toBe('2026');
+    expect(featured?.inProgress).toBe(true);
+  });
+
+  it('ends the season on Finals night as soon as a placement is set', () => {
+    const now = DateTime.fromISO('2026-08-08T23:00', {
+      zone: 'America/New_York',
+    });
+    const featured = getFeaturedSeason(
+      [SEASON_2024, SEASON_2025, SEASON_2026_PLACED],
+      now,
+    );
+    expect(featured?.season.year).toBe('2026');
+    expect(featured?.inProgress).toBe(false);
   });
 });


### PR DESCRIPTION
## Problem

On Finals night (Sat Aug 8), the 2026 Finals score and `placement: 1` were logged, but the Home page kept its "in progress" wording and presentation until the next day.

`getFeaturedSeason` derived `inProgress` purely from the calendar:

```ts
const inProgress = finalsDate >= now.startOf('day');
```

On Finals day itself, `finalsDate >= today` is true for the entire day, so the state only flipped at midnight — regardless of the result being recorded. (The Tour page uses a separate, data-driven `isInProgress` in `src/lib/utils/tour.ts`, which is why only the Home page was stuck.)

## Fix

A recorded `placement` now ends the season:

```ts
const inProgress =
  season.placement == null && finalsDate >= now.startOf('day');
```

The Home page and the Score History chart both read this helper, so both switch to their completed presentation (final score label, finals-night ranking, no "Today" marker, no projection) as soon as the result lands.

## Tests

Two cases added to `tests/unit/featured-season.test.ts`, written failing first:

- Finals day, no placement yet → still in progress
- Finals night, placement set → not in progress

Verified: `pnpm vitest run` — 150 passed; `pnpm lint` — clean; `pnpm test:e2e` — 44 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)