### PR TITLE
Let a placement end the season on the Tour page too

### DIFF
--- a/src/lib/utils/tour.ts
+++ b/src/lib/utils/tour.ts
@@ -46,8 +46,14 @@ export function scoreAsOfDay(season: SeasonScores, day: number): number | null {
   return result;
 }
 
-/** A season with both competed shows and still-scheduled (uncompeted) shows. */
+/**
+ * A season with both competed shows and still-scheduled (uncompeted) shows.
+ * A recorded placement always ends the season, so a stop that never got a
+ * result logged can't strand a finished tour in its in-progress state — the
+ * same rule `getFeaturedSeason` applies to the Home page.
+ */
 export function isInProgress(season: SeasonScores): boolean {
+  if (season.placement != null) return false;
   const hasScheduled = season.scores.some((s) => s.score === undefined);
   const hasNumeric = season.scores.some((s) => typeof s.score === 'number');
   return hasScheduled && hasNumeric;

--- a/tests/unit/tour.test.ts
+++ b/tests/unit/tour.test.ts
@@ -38,6 +38,18 @@ const S2025_INPROGRESS: SeasonScores = {
   ],
 };
 
+// Placed at Finals, but a mid-tour stop was never given a result.
+const S2025_PLACED_WITH_GAP: SeasonScores = {
+  year: '2025',
+  endDate: '2025-08-09',
+  placement: 2,
+  scores: [
+    { date: '2025-06-23', location: 'Akron, OH', score: 75 },
+    { date: '2025-07-18', location: 'San Antonio, TX' }, // never filled in
+    { date: '2025-08-09', location: 'Indianapolis, IN', score: 98 },
+  ],
+};
+
 describe('buildTour', () => {
   it('includes numeric and null scores, excludes not-yet-competed', () => {
     const tour = buildTour(S2024);
@@ -76,6 +88,10 @@ describe('isInProgress', () => {
 
   it('is false for a fully completed season', () => {
     expect(isInProgress(S2024)).toBe(false);
+  });
+
+  it('is false once a placement is set, even with an unfilled stop', () => {
+    expect(isInProgress(S2025_PLACED_WITH_GAP)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Follow-up to #445, which made a recorded `placement` end the featured season's "in progress" state on the Home page. The Tour page used a separate, schedule-shaped rule:

```ts
const hasScheduled = season.scores.some((s) => s.score === undefined);
const hasNumeric = season.scores.some((s) => typeof s.score === 'number');
return hasScheduled && hasNumeric;
```

So a stop that never gets a result logged — canceled, or a score that's simply never published — keeps a finished season in progress indefinitely. The season page would render the placement chip and the pulsing "Season in progress" badge side by side, and the subtitle and `TourStats` would stay on the "N shows so far / season high" wording instead of the final score and all-time finals rank.

`isInProgress` now short-circuits on a recorded placement, so both pages agree on when a season is done.

## Tests

Added to `tests/unit/tour.test.ts`, written failing first — a season with `placement: 2` and an unfilled mid-tour stop:

```
× is false once a placement is set, even with an unfilled stop
  → expected true to be false
```

Verified after: `pnpm vitest run` — 151 passed; `pnpm lint` — clean; `pnpm test:e2e` — 44 passed.

No current season data hits this case, so the live site is unchanged; this closes the gap before it can bite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)